### PR TITLE
Document browser-service goal: stateful sessions on a real-time socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,37 @@
 # What is browser-service?
 
-A standalone HTTP service that exposes Selenium/Appium browser sessions to remote callers. Agents, audit services, and anything else that needs a browser can open a session, drive it, and close it — without embedding a WebDriver library.
+**Browsers as a service.** A standalone service that hands out live, dedicated browser instances to other applications and agents on demand, so they can drive a real browser without embedding a WebDriver library.
 
-The engine is being lifted almost verbatim from `LookseeCore/looksee-browser/` (already a self-contained Java module with zero intra-repo coupling) and wrapped in a Spring Boot REST layer. Selenium 3 / Appium 7 get upgraded to Selenium 4 / Appium 8 during the move.
+The engine is being lifted almost verbatim from `LookseeCore/looksee-browser/` (already a self-contained Java module with zero intra-repo coupling) and wrapped in a Spring Boot service layer. Selenium 3 / Appium 7 get upgraded to Selenium 4 / Appium 8 during the move.
+
+## Goal
+
+Browser interactions are inherently stateful — checking email, filling out a form, completing a checkout flow, etc. all rely on the browser remembering what just happened. A caller can't drive that kind of multi-step task across stateless, ephemeral sessions; the browser needs continuity from one step to the next.
+
+This service provides that continuity:
+
+1. A caller asks the service for a connection.
+2. The service routes them to a specific browser instance and **holds that connection open for the duration of the session**.
+3. Every step the caller performs — navigate, click, extract, screenshot — runs against the same browser instance the connection was opened against.
+4. When the caller is done with their task, they close the connection, which frees the browser for the next caller.
+
+The primary connection is a **socket connection** so the caller can interact with the browser in real time and stream results back. On top of that socket, the service also exposes the full set of asynchronous HTTP endpoints (navigate, click, find element, extract, screenshot, scroll, etc.) so callers that prefer a request/response style can use those instead — provided they include the `session_id` so the operation lands on the right browser.
+
+If a caller goes idle for **5 minutes** the session times out and the browser is closed automatically. If that caller later comes back asking for the same `session_id`, the service responds with a clear "session expired and has been closed" error so the caller knows it has to open a new connection rather than silently resuming on a fresh browser.
+
+Each caller is capped at **10 concurrent sessions**. Beyond that, requests for new sessions are rejected until one is closed (either explicitly by the caller or by the idle timeout).
 
 ## Who this is for
 
-- **LookseeCore** — today's consumer. Existing services (PageBuilder, element-enrichment, journeyExecutor, audits, etc.) migrate behind a compatibility shim: `BrowserService` keeps its public signatures but delegates to an HTTP client instead of an in-process `Browser`.
-- **Khala** ([brandonkindred/Khala-Agentic-AI-Teams](https://github.com/brandonkindred/Khala-Agentic-AI-Teams)) — Python agentic-teams project that needs a browsing capability. Talks to this service over plain HTTP; no Java dependency.
+- **LookseeCore** — today's consumer. Existing services (PageBuilder, element-enrichment, journeyExecutor, audits, etc.) migrate behind a compatibility shim: `BrowserService` keeps its public signatures but delegates to a remote client instead of an in-process `Browser`.
+- **Khala** ([brandonkindred/Khala-Agentic-AI-Teams](https://github.com/brandonkindred/Khala-Agentic-AI-Teams)) — Python agentic-teams project that needs a browsing capability. Talks to this service over the wire; no Java dependency.
 - **Anyone else** — the service is open source (MIT) and intentionally generic. No Look-see domain concepts leak into the public API.
 
 ## Session model
 
-Browser interactions are stateful. The shape is: **create → interact → close**.
+Browser interactions are stateful. The shape is: **open connection → interact → close connection**. Every operation in a session runs against the same dedicated browser instance the connection was opened against.
+
+The HTTP surface below is the asynchronous side of the API. The real-time socket connection (the primary interaction channel) is layered on top of the same `session_id` and is documented in the OpenAPI spec.
 
 ```bash
 # 1. Open a session.
@@ -43,11 +62,11 @@ curl -X POST http://browser-service/v1/sessions/abc123/screenshot \
   -d '{"strategy": "full_page_shutterbug"}' \
   --output page.png
 
-# 6. Close.
+# 6. Close. Frees the browser and counts against the caller's 10-session cap.
 curl -X DELETE http://browser-service/v1/sessions/abc123
 ```
 
-Idle sessions expire after 5 minutes; all sessions expire after 30 minutes, no matter what. The registry reaps them automatically.
+Idle sessions expire after 5 minutes; all sessions expire after 30 minutes, no matter what. The registry reaps them automatically. Operations against a `session_id` that has been reaped return a `session_expired` error so the caller can react instead of silently retrying on a fresh browser.
 
 For the trivial "open → navigate → screenshot → close" path, `POST /v1/capture` collapses all of the above into one request.
 
@@ -55,25 +74,25 @@ For the trivial "open → navigate → screenshot → close" path, `POST /v1/cap
 
 | Area | Decision |
 |---|---|
-| Transport | HTTP / JSON (OpenAPI 3.1 in `openapi.yaml`) |
+| Transport | Real-time socket connection per session (primary), plus HTTP / JSON endpoints (OpenAPI 3.1 in `openapi.yaml`) for async operations |
 | Screenshots | Default returns `image/png` bytes. `?encoding=base64` returns JSON for MCP / non-binary callers |
 | Screenshot storage | **Caller uploads.** Service holds bytes only long enough to return them |
-| Session model | Stateful sessions, opaque `session_id`, idle + absolute TTL |
+| Session model | Stateful sessions pinned to a specific browser instance, opaque `session_id`, 5-minute idle TTL + 30-minute absolute TTL, explicit `session_expired` error after reap |
 | Mobile | Appium (Android / iOS) included. Same session API; mobile gestures use `/element/touch` |
 | Engine | Selenium 4 + Appium Java Client 8 (upgraded from today's Selenium 3 / Appium 7) |
 | Upstream | Existing Selenium Grid (in `LookseeIaC`) + optional BrowserStack — unchanged |
-| Clients | Java client (for LookseeCore's shim). Khala uses the HTTP API directly |
-| Concurrency | 20 concurrent sessions per instance; 429 once capped. Horizontal scale via replicas |
+| Clients | Java client (for LookseeCore's shim). Khala uses the API directly |
+| Concurrency | **10 concurrent sessions per caller**; further `POST /sessions` requests get a 429 until one is closed. Horizontal scale via replicas |
 | Licence | MIT (inherited from Look-see) |
 
 ## Explicitly out of MVP
 
 Listed here so nothing gets forgotten:
 
-- **Authentication.** Service runs on a private network (VPC-only ingress). API keys / OAuth / per-tenant isolation deferred.
-- **Rate limits / quotas.** Need auth first to key off.
+- **Authentication.** Service runs on a private network (VPC-only ingress). API keys / OAuth / per-tenant isolation deferred. The 10-sessions-per-caller cap is keyed off whatever caller identity the network layer surfaces (source IP, header) until proper auth lands.
+- **Rate limits / quotas beyond the per-caller session cap.** Need auth first to key off properly.
 - **Network egress policy.** SSRF guard against `localhost` / `169.254.169.254` / private CIDRs — defer to post-auth.
-- **Streaming events.** No WebSocket or SSE at MVP. Page-load progress, console logs, network events, DOM mutations all come later if a caller asks.
+- **Push events on the socket beyond operation results.** The real-time socket carries operation results in this phase. Page-load progress, console logs, network events, DOM mutations come later if a caller asks.
 - **MCP server.** The REST endpoints are named so each maps 1:1 to a future MCP tool (`browser.navigate`, `browser.screenshot`, etc.) but no MCP wrapper ships in MVP.
 - **Live-view UI.** Vendors like Browserbase ship a debug panel (VNC/CDP stream). Possible later.
 - **Cloud-storage backends.** Service never uploads to GCS/S3; callers handle storage.

--- a/docs/design/openapi-draft-v1.yaml
+++ b/docs/design/openapi-draft-v1.yaml
@@ -2,11 +2,13 @@ openapi: 3.1.0
 info:
   title: Browser Service
   version: 0.1.0-draft
-  summary: Remote browser sessions for programmatic web interaction.
+  summary: Browsers as a service — dedicated browser instances handed out to applications and agents on demand.
   description: |
-    Standalone service that exposes Selenium/Appium browser sessions over HTTP
-    so agents, audit services, and other clients can drive a browser without
-    embedding a WebDriver library.
+    Standalone service that hands out live, dedicated browser instances to
+    applications and agents on demand. The primary interaction channel is a
+    real-time socket connection per session; this OpenAPI document describes
+    the asynchronous HTTP surface that runs alongside it (navigate, click,
+    extract, screenshot, etc.).
 
     This spec is a **design draft** being developed on Look-see branch
     `claude/extract-browsing-service-MgOw3`. It will be moved to the
@@ -14,19 +16,33 @@ info:
 
     ## Session model
 
-    Browser interactions are stateful. A caller creates a session, performs
-    one or more actions against it, then closes it. Sessions are identified
-    by an opaque `session_id` embedded in each URL path after creation.
+    Browser interactions are stateful. A caller opens a connection, the
+    service pins them to a specific browser instance, and every operation
+    in the session — whether sent over the socket or one of the HTTP
+    endpoints below — runs against that same browser. The caller closes the
+    connection when their task is done, freeing the browser for the next
+    caller.
+
+    Sessions are identified by an opaque `session_id` embedded in each URL
+    path (and exchanged on the socket).
 
     Idle sessions are closed automatically after the configured idle TTL
     (default 5 minutes); all sessions are closed after the absolute TTL
-    (default 30 minutes) regardless of activity.
+    (default 30 minutes) regardless of activity. Operations against a
+    `session_id` that has already been reaped return a `session_expired`
+    error so the caller knows it must open a new connection rather than
+    silently resuming on a fresh browser.
+
+    Each caller is capped at **10 concurrent sessions**. `POST /sessions`
+    returns 429 once the cap is reached, until one is closed (either
+    explicitly by the caller or by the idle timeout).
 
     ## Not in MVP
 
     - Authentication (service runs on a private network)
-    - Rate limits and per-tenant quotas
-    - Streaming events (WebSocket/SSE)
+    - Rate limits and per-tenant quotas beyond the 10-sessions-per-caller cap
+    - Push events on the socket beyond operation results (page-load progress,
+      console logs, network events, DOM mutations)
     - Screenshot upload to cloud storage (caller uploads)
     - MCP server (endpoints are named to map 1:1 to future MCP tools)
 


### PR DESCRIPTION
## Summary

Capture the stated design intent for browser-service in the README and the OpenAPI design draft.

- New **Goal** section in the README: the service hands out dedicated browser instances on demand, pins each caller to a specific browser for the duration of a session, and runs every operation in that session against the same browser.
- The primary interaction channel is a **real-time socket connection**; the HTTP surface is the asynchronous side of the same API and lives alongside it.
- Concurrency rule changed from "20 per instance" to **10 concurrent sessions per caller** with a 429 once capped.
- Idle timeout (5 min) now explicitly returns a `session_expired` error if a caller comes back to a reaped `session_id`, so they know to open a new connection rather than silently resuming on a fresh browser.
- WebSocket/streaming pulled out of the "out of MVP" list (now in scope as the primary transport); the remaining streaming line is narrowed to "push events beyond operation results."
- Design draft (`docs/design/openapi-draft-v1.yaml`) updated to match.

No code changes — docs only.

## Test plan

- [ ] Skim `README.md` end-to-end and confirm the Goal / Session model / MVP scope sections are consistent.
- [ ] Skim `docs/design/openapi-draft-v1.yaml` `info.description` and confirm it matches the README's framing.

https://claude.ai/code/session_01PfxQMP1wnoUVBw7H32dZbP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfxQMP1wnoUVBw7H32dZbP)_