### PR TITLE
[WS-B] Server-pushed events: alerts, console / browser logs, navigation

### DIFF
--- a/api/src/main/java/io/browserservice/api/config/EngineProperties.java
+++ b/api/src/main/java/io/browserservice/api/config/EngineProperties.java
@@ -23,7 +23,14 @@ public record EngineProperties(
             @DefaultValue("32") int commandQueueDepth,
             @DefaultValue("300") int idleCloseSeconds,
             @DefaultValue("64") int outboundBufferKiB,
-            @DefaultValue("10000") int sendTimeLimitMs) {
+            @DefaultValue("10000") int sendTimeLimitMs,
+            @DefaultValue("true") boolean alertPushEnabled,
+            @DefaultValue("250") int alertPollMs,
+            @DefaultValue("true") boolean consolePushEnabled,
+            @DefaultValue("1000") int consolePollMs,
+            @DefaultValue("true") boolean navigationPushEnabled,
+            @DefaultValue("2000") int navigationPollMs,
+            @DefaultValue("50") int watcherLockTimeoutMs) {
     }
 
     public record SeleniumProps(

--- a/api/src/main/java/io/browserservice/api/config/WebSocketBeans.java
+++ b/api/src/main/java/io/browserservice/api/config/WebSocketBeans.java
@@ -1,0 +1,27 @@
+package io.browserservice.api.config;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Beans the WebSocket layer needs that don't fit naturally inside {@link WebSocketConfig}
+ * (which already has a constructor dependency on {@code SessionWebSocketHandler}). Lives
+ * in a separate config class so the shared scheduler can be injected into both the
+ * handler and the watcher coordinator without a construction-time cycle.
+ */
+@Configuration
+public class WebSocketBeans {
+
+    @Bean(destroyMethod = "shutdownNow")
+    public ScheduledExecutorService webSocketScheduler() {
+        AtomicInteger counter = new AtomicInteger();
+        return Executors.newScheduledThreadPool(2, r -> {
+            Thread t = new Thread(r, "ws-scheduler-" + counter.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        });
+    }
+}

--- a/api/src/main/java/io/browserservice/api/service/AlertService.java
+++ b/api/src/main/java/io/browserservice/api/service/AlertService.java
@@ -25,13 +25,21 @@ public class AlertService {
 
     public AlertStateResponse getAlert(UUID sessionId) {
         SessionHandle handle = registry.get(sessionId);
-        return locks.doWithLock(handle, h -> {
-            Alert alert = findAlert(h.driver());
-            if (alert == null) {
-                return new AlertStateResponse(false, null);
-            }
-            return new AlertStateResponse(true, safeAlertText(alert));
-        });
+        return locks.doWithLock(handle, AlertService::peekAlert);
+    }
+
+    /**
+     * Reads the current alert state assuming the caller already holds the session lock.
+     * Used by both the user-facing {@link #getAlert(UUID)} (under {@code doWithLock}) and
+     * by the WS {@code AlertWatcher} (under {@code tryDoWithLock}, which must not refresh
+     * idle TTL).
+     */
+    public static AlertStateResponse peekAlert(SessionHandle handle) {
+        Alert alert = findAlert(handle.driver());
+        if (alert == null) {
+            return new AlertStateResponse(false, null);
+        }
+        return new AlertStateResponse(true, safeAlertText(alert));
     }
 
     public void respond(UUID sessionId, AlertRespondRequest req) {

--- a/api/src/main/java/io/browserservice/api/session/SessionLocks.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionLocks.java
@@ -2,6 +2,7 @@ package io.browserservice.api.session;
 
 import io.browserservice.api.config.EngineProperties;
 import io.browserservice.api.error.SessionBusyException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.springframework.stereotype.Component;
 
@@ -40,6 +41,32 @@ public class SessionLocks {
         });
     }
 
+    /**
+     * Acquires the session lock with a custom short timeout for server-driven background
+     * observers (the WS event watchers). Returns {@link Optional#empty()} on contention or
+     * interrupt — callers must not block on it.
+     *
+     * <p>Critically, this variant does <strong>not</strong> call {@link SessionHandle#touch()}.
+     * Watcher polling must not refresh idle TTL: only real user operations keep a session alive.
+     */
+    public <T> Optional<T> tryDoWithLock(SessionHandle handle, long timeoutMs, SessionWork<T> work) {
+        boolean locked = false;
+        try {
+            locked = handle.lock().tryLock(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return Optional.empty();
+        }
+        if (!locked) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(work.execute(handle));
+        } finally {
+            handle.lock().unlock();
+        }
+    }
+
     @FunctionalInterface
     public interface SessionWork<T> {
         T execute(SessionHandle handle);
@@ -50,3 +77,4 @@ public class SessionLocks {
         void execute(SessionHandle handle);
     }
 }
+

--- a/api/src/main/java/io/browserservice/api/ws/CommandDispatcher.java
+++ b/api/src/main/java/io/browserservice/api/ws/CommandDispatcher.java
@@ -27,6 +27,7 @@ import io.browserservice.api.service.BrowserOperationsService;
 import io.browserservice.api.service.CaptureService;
 import io.browserservice.api.service.ElementOperationsService;
 import io.browserservice.api.service.SessionService;
+import io.browserservice.api.ws.push.WatcherCoordinator;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.io.ByteArrayInputStream;
@@ -59,6 +60,7 @@ public class CommandDispatcher {
     private final AlertService alertService;
     private final CaptureService captureService;
     private final WsSessionOwnership ownership;
+    private final WatcherCoordinator watchers;
     private final Validator validator;
     private final ObjectMapper mapper;
 
@@ -70,6 +72,7 @@ public class CommandDispatcher {
                              AlertService alertService,
                              CaptureService captureService,
                              WsSessionOwnership ownership,
+                             WatcherCoordinator watchers,
                              Validator validator,
                              ObjectMapper mapper) {
         this.sessionService = sessionService;
@@ -78,6 +81,7 @@ public class CommandDispatcher {
         this.alertService = alertService;
         this.captureService = captureService;
         this.ownership = ownership;
+        this.watchers = watchers;
         this.validator = validator;
         this.mapper = mapper;
         this.handlers = buildHandlers();
@@ -101,6 +105,7 @@ public class CommandDispatcher {
             SessionResponse resp = sessionService.create(req);
             ownership.claim(resp.sessionId(), conn.caller());
             conn.bind(resp.sessionId());
+            watchers.onSessionAttached(resp.sessionId(), conn);
             return resp;
         });
         h.put("session.attach", (conn, params) -> {
@@ -114,12 +119,14 @@ public class CommandDispatcher {
             // and fail every subsequent session.create / session.attach with already_bound.
             Object state = sessionService.describe(sessionId);
             conn.bind(sessionId);
+            watchers.onSessionAttached(sessionId, conn);
             return state;
         });
         h.put("session.describe", (conn, params) -> sessionService.describe(requireBound(conn)));
         h.put("session.close", (conn, params) -> {
             UUID id = requireBound(conn);
             sessionService.close(id);
+            watchers.onSessionDetached(id, conn);
             ownership.release(id);
             conn.unbind();
             return null;

--- a/api/src/main/java/io/browserservice/api/ws/SessionWebSocketHandler.java
+++ b/api/src/main/java/io/browserservice/api/ws/SessionWebSocketHandler.java
@@ -9,7 +9,7 @@ import io.browserservice.api.error.RequestIdFilter;
 import io.browserservice.api.error.UnknownFrameTypeException;
 import io.browserservice.api.ws.dto.CommandFrame;
 import io.browserservice.api.ws.dto.ResponseFrame;
-import jakarta.annotation.PreDestroy;
+import io.browserservice.api.ws.push.WatcherCoordinator;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -40,19 +40,18 @@ public class SessionWebSocketHandler extends TextWebSocketHandler {
     private final CommandDispatcher dispatcher;
     private final ObjectMapper mapper;
     private final ScheduledExecutorService scheduler;
+    private final WatcherCoordinator watchers;
     private final EngineProperties.WebSocketProps props;
 
     public SessionWebSocketHandler(CommandDispatcher dispatcher, ObjectMapper mapper,
+                                   ScheduledExecutorService webSocketScheduler,
+                                   WatcherCoordinator watchers,
                                    EngineProperties props) {
         this.dispatcher = dispatcher;
         this.mapper = mapper;
+        this.scheduler = webSocketScheduler;
+        this.watchers = watchers;
         this.props = props.webSocket();
-        this.scheduler = Executors.newScheduledThreadPool(2, namedThreadFactory("ws-scheduler"));
-    }
-
-    @PreDestroy
-    void shutdown() {
-        scheduler.shutdownNow();
     }
 
     @Override
@@ -152,6 +151,10 @@ public class SessionWebSocketHandler extends TextWebSocketHandler {
         }
         Connection conn = (Connection) session.getAttributes().remove(Connection.ATTRIBUTE);
         if (conn != null) {
+            UUID bound = conn.boundSessionId();
+            if (bound != null) {
+                watchers.onSessionDetached(bound, conn);
+            }
             conn.commands().shutdownNow();
             log.debug("ws closed connectionId={} status={}", conn.connectionId(), status);
         }

--- a/api/src/main/java/io/browserservice/api/ws/WsSessionConnections.java
+++ b/api/src/main/java/io/browserservice/api/ws/WsSessionConnections.java
@@ -1,0 +1,65 @@
+package io.browserservice.api.ws;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * Per-session set of WebSocket connections currently bound to that session, used so the
+ * WS event watchers (alerts, console, navigation) can fan out a single tick to every
+ * connected listener. The booleans returned by {@link #attach} and {@link #detach} let
+ * the {@code WatcherCoordinator} start watchers exactly once on the first attach and stop
+ * them exactly once on the last detach.
+ */
+@Component
+public class WsSessionConnections {
+
+    private final ConcurrentHashMap<UUID, Set<Connection>> bound = new ConcurrentHashMap<>();
+
+    /** @return true iff this is the first connection bound to {@code sessionId}. */
+    public boolean attach(UUID sessionId, Connection conn) {
+        boolean[] firstHolder = {false};
+        bound.compute(sessionId, (id, existing) -> {
+            if (existing == null) {
+                Set<Connection> set = Collections.newSetFromMap(new ConcurrentHashMap<>());
+                set.add(conn);
+                firstHolder[0] = true;
+                return set;
+            }
+            existing.add(conn);
+            return existing;
+        });
+        return firstHolder[0];
+    }
+
+    /** @return true iff this was the last connection bound to {@code sessionId}. */
+    public boolean detach(UUID sessionId, Connection conn) {
+        boolean[] lastHolder = {false};
+        bound.compute(sessionId, (id, existing) -> {
+            if (existing == null) {
+                return null;
+            }
+            existing.remove(conn);
+            if (existing.isEmpty()) {
+                lastHolder[0] = true;
+                return null;
+            }
+            return existing;
+        });
+        return lastHolder[0];
+    }
+
+    /** Snapshot of the connections currently bound to {@code sessionId}. */
+    public Collection<Connection> snapshot(UUID sessionId) {
+        Set<Connection> set = bound.get(sessionId);
+        return set == null ? List.of() : List.copyOf(set);
+    }
+
+    public boolean isTracked(UUID sessionId) {
+        return bound.containsKey(sessionId);
+    }
+}

--- a/api/src/main/java/io/browserservice/api/ws/dto/EventFrame.java
+++ b/api/src/main/java/io/browserservice/api/ws/dto/EventFrame.java
@@ -1,0 +1,13 @@
+package io.browserservice.api.ws.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record EventFrame(String type, String kind, Object data) {
+
+    public static final String TYPE = "event";
+
+    public static EventFrame of(String kind, Object data) {
+        return new EventFrame(TYPE, kind, data);
+    }
+}

--- a/api/src/main/java/io/browserservice/api/ws/push/AlertWatcher.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/AlertWatcher.java
@@ -1,0 +1,58 @@
+package io.browserservice.api.ws.push;
+
+import io.browserservice.api.dto.AlertStateResponse;
+import io.browserservice.api.service.AlertService;
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.ws.dto.EventFrame;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Polls {@code driver.switchTo().alert()} on a short cadence and pushes
+ * {@code event{kind:"alert.appeared"}} on the rising edge — not once per tick while the
+ * alert remains visible, and not after dismissal.
+ *
+ * <p>Reuses {@link AlertService#peekAlert(SessionHandle)} (the lock-free helper extracted
+ * for this watcher) so the alert detection stays consistent with the REST surface.
+ */
+public final class AlertWatcher implements SessionEventWatcher {
+
+    private final UUID sessionId;
+    private final SessionHandle handle;
+    private final SessionLocks locks;
+    private final EventBroadcaster broadcaster;
+    private final int periodMs;
+    private final long lockTimeoutMs;
+    private final AtomicBoolean previouslyPresent = new AtomicBoolean(false);
+
+    public AlertWatcher(UUID sessionId, SessionHandle handle, SessionLocks locks,
+                        EventBroadcaster broadcaster, int periodMs, long lockTimeoutMs) {
+        this.sessionId = sessionId;
+        this.handle = handle;
+        this.locks = locks;
+        this.broadcaster = broadcaster;
+        this.periodMs = periodMs;
+        this.lockTimeoutMs = lockTimeoutMs;
+    }
+
+    @Override
+    public int periodMs() {
+        return periodMs;
+    }
+
+    @Override
+    public void tick() {
+        locks.tryDoWithLock(handle, lockTimeoutMs, AlertService::peekAlert)
+                .ifPresent(this::emitOnRisingEdge);
+    }
+
+    private void emitOnRisingEdge(AlertStateResponse state) {
+        boolean wasPresent = previouslyPresent.getAndSet(state.present());
+        if (state.present() && !wasPresent) {
+            broadcaster.broadcast(sessionId, EventFrame.of("alert.appeared",
+                    Map.of("text", state.text() == null ? "" : state.text())));
+        }
+    }
+}

--- a/api/src/main/java/io/browserservice/api/ws/push/BrowserLogDrain.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/BrowserLogDrain.java
@@ -1,0 +1,103 @@
+package io.browserservice.api.ws.push;
+
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.ws.dto.EventFrame;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.openqa.selenium.UnsupportedCommandException;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drains {@code driver.manage().logs().get(LogType.BROWSER)} on a short cadence and
+ * pushes one {@code event{kind:"console.log"}} frame per log entry.
+ *
+ * <p>Some drivers (Safari, Appium platforms, and Chrome sessions started without
+ * {@code goog:loggingPrefs}) do not support browser logs. On the first
+ * {@link UnsupportedCommandException} or equivalent driver error we self-disable for the
+ * remainder of the session — no error spam, no flapping.
+ */
+public final class BrowserLogDrain implements SessionEventWatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(BrowserLogDrain.class);
+
+    private final UUID sessionId;
+    private final SessionHandle handle;
+    private final SessionLocks locks;
+    private final EventBroadcaster broadcaster;
+    private final int periodMs;
+    private final long lockTimeoutMs;
+    private final AtomicBoolean disabled = new AtomicBoolean(false);
+
+    public BrowserLogDrain(UUID sessionId, SessionHandle handle, SessionLocks locks,
+                           EventBroadcaster broadcaster, int periodMs, long lockTimeoutMs) {
+        this.sessionId = sessionId;
+        this.handle = handle;
+        this.locks = locks;
+        this.broadcaster = broadcaster;
+        this.periodMs = periodMs;
+        this.lockTimeoutMs = lockTimeoutMs;
+    }
+
+    @Override
+    public int periodMs() {
+        return periodMs;
+    }
+
+    @Override
+    public void tick() {
+        if (disabled.get()) {
+            return;
+        }
+        locks.tryDoWithLock(handle, lockTimeoutMs, this::drain);
+    }
+
+    private List<LogEntry> drain(SessionHandle h) {
+        List<LogEntry> entries;
+        try {
+            entries = h.driver().manage().logs().get(LogType.BROWSER).getAll();
+        } catch (UnsupportedCommandException e) {
+            disable("UnsupportedCommandException");
+            return null;
+        } catch (WebDriverException e) {
+            String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+            if (msg.contains("not implemented")
+                    || msg.contains("command not found")
+                    || msg.contains("unsupported")) {
+                disable(e.getClass().getSimpleName() + ": " + e.getMessage());
+                return null;
+            }
+            log.debug("browser log read failed for session={}: {}", sessionId, e.toString());
+            return null;
+        }
+        for (LogEntry entry : entries) {
+            broadcaster.broadcast(sessionId, EventFrame.of("console.log", toData(entry)));
+        }
+        return entries;
+    }
+
+    private static Map<String, Object> toData(LogEntry entry) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("level", entry.getLevel().getName());
+        out.put("message", entry.getMessage());
+        out.put("ts", entry.getTimestamp());
+        return out;
+    }
+
+    private void disable(String reason) {
+        if (disabled.compareAndSet(false, true)) {
+            log.info("browser log drain disabled for session={} reason={}", sessionId, reason);
+        }
+    }
+
+    boolean isDisabled() {
+        return disabled.get();
+    }
+}

--- a/api/src/main/java/io/browserservice/api/ws/push/BrowserLogDrain.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/BrowserLogDrain.java
@@ -56,31 +56,35 @@ public final class BrowserLogDrain implements SessionEventWatcher {
         if (disabled.get()) {
             return;
         }
-        locks.tryDoWithLock(handle, lockTimeoutMs, this::drain);
+        // Collect entries under the session lock; broadcast OUTSIDE the lock so a slow WS
+        // writer (backpressure, large fan-out) cannot delay user commands that also need
+        // this lock.
+        List<LogEntry> entries = locks.tryDoWithLock(handle, lockTimeoutMs, this::drain).orElse(null);
+        if (entries == null || entries.isEmpty()) {
+            return;
+        }
+        for (LogEntry entry : entries) {
+            broadcaster.broadcast(sessionId, EventFrame.of("console.log", toData(entry)));
+        }
     }
 
     private List<LogEntry> drain(SessionHandle h) {
-        List<LogEntry> entries;
         try {
-            entries = h.driver().manage().logs().get(LogType.BROWSER).getAll();
+            return h.driver().manage().logs().get(LogType.BROWSER).getAll();
         } catch (UnsupportedCommandException e) {
             disable("UnsupportedCommandException");
-            return null;
+            return List.of();
         } catch (WebDriverException e) {
             String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
             if (msg.contains("not implemented")
                     || msg.contains("command not found")
                     || msg.contains("unsupported")) {
                 disable(e.getClass().getSimpleName() + ": " + e.getMessage());
-                return null;
+                return List.of();
             }
             log.debug("browser log read failed for session={}: {}", sessionId, e.toString());
-            return null;
+            return List.of();
         }
-        for (LogEntry entry : entries) {
-            broadcaster.broadcast(sessionId, EventFrame.of("console.log", toData(entry)));
-        }
-        return entries;
     }
 
     private static Map<String, Object> toData(LogEntry entry) {

--- a/api/src/main/java/io/browserservice/api/ws/push/EventBroadcaster.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/EventBroadcaster.java
@@ -1,0 +1,50 @@
+package io.browserservice.api.ws.push;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.browserservice.api.ws.Connection;
+import io.browserservice.api.ws.WsSessionConnections;
+import io.browserservice.api.ws.dto.EventFrame;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+
+/**
+ * Serializes event frames once and writes them to every connection currently bound to the
+ * given session. Outbound writes go through each connection's
+ * {@code ConcurrentWebSocketSessionDecorator}, the same path command responses use, so
+ * watcher pushes and command responses cannot interleave on the wire.
+ */
+@Component
+public class EventBroadcaster {
+
+    private static final Logger log = LoggerFactory.getLogger(EventBroadcaster.class);
+
+    private final WsSessionConnections connections;
+    private final ObjectMapper mapper;
+
+    public EventBroadcaster(WsSessionConnections connections, ObjectMapper mapper) {
+        this.connections = connections;
+        this.mapper = mapper;
+    }
+
+    public void broadcast(UUID sessionId, EventFrame frame) {
+        String json;
+        try {
+            json = mapper.writeValueAsString(frame);
+        } catch (Exception e) {
+            log.warn("ws event serialize failed kind={}: {}", frame.kind(), e.toString());
+            return;
+        }
+        TextMessage msg = new TextMessage(json);
+        for (Connection conn : connections.snapshot(sessionId)) {
+            try {
+                conn.out().sendMessage(msg);
+            } catch (IOException e) {
+                log.debug("ws event push failed connectionId={}: {}", conn.connectionId(), e.toString());
+            }
+        }
+    }
+}

--- a/api/src/main/java/io/browserservice/api/ws/push/NavigationWatcher.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/NavigationWatcher.java
@@ -1,0 +1,91 @@
+package io.browserservice.api.ws.push;
+
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.ws.dto.EventFrame;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.UnhandledAlertException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Polls {@code [location.href, document.readyState]} on a slow cadence and pushes
+ * {@code event{kind:"navigation.changed"}} when either value changes. Suppresses
+ * duplicate consecutive ticks. {@link UnhandledAlertException} is swallowed — the
+ * alert watcher will surface it.
+ */
+public final class NavigationWatcher implements SessionEventWatcher {
+
+    private static final String SCRIPT = "return [location.href, document.readyState];";
+    private static final Logger log = LoggerFactory.getLogger(NavigationWatcher.class);
+
+    private final UUID sessionId;
+    private final SessionHandle handle;
+    private final SessionLocks locks;
+    private final EventBroadcaster broadcaster;
+    private final int periodMs;
+    private final long lockTimeoutMs;
+    private final AtomicReference<Snapshot> previous = new AtomicReference<>();
+
+    public NavigationWatcher(UUID sessionId, SessionHandle handle, SessionLocks locks,
+                             EventBroadcaster broadcaster, int periodMs, long lockTimeoutMs) {
+        this.sessionId = sessionId;
+        this.handle = handle;
+        this.locks = locks;
+        this.broadcaster = broadcaster;
+        this.periodMs = periodMs;
+        this.lockTimeoutMs = lockTimeoutMs;
+    }
+
+    @Override
+    public int periodMs() {
+        return periodMs;
+    }
+
+    @Override
+    public void tick() {
+        locks.tryDoWithLock(handle, lockTimeoutMs, this::probe)
+                .ifPresent(this::emitOnChange);
+    }
+
+    private Snapshot probe(SessionHandle h) {
+        WebDriver driver = h.driver();
+        if (!(driver instanceof JavascriptExecutor js)) {
+            return null;
+        }
+        try {
+            Object raw = js.executeScript(SCRIPT);
+            if (raw instanceof List<?> list && list.size() >= 2) {
+                String url = list.get(0) == null ? null : list.get(0).toString();
+                String readyState = list.get(1) == null ? null : list.get(1).toString();
+                return new Snapshot(url, readyState);
+            }
+        } catch (UnhandledAlertException e) {
+            return null;
+        } catch (WebDriverException e) {
+            log.debug("navigation probe failed for session={}: {}", sessionId, e.toString());
+        }
+        return null;
+    }
+
+    private void emitOnChange(Snapshot snap) {
+        Snapshot prior = previous.getAndSet(snap);
+        if (Objects.equals(prior, snap)) {
+            return;
+        }
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("url", snap.url());
+        data.put("ready_state", snap.readyState());
+        broadcaster.broadcast(sessionId, EventFrame.of("navigation.changed", data));
+    }
+
+    private record Snapshot(String url, String readyState) {}
+}

--- a/api/src/main/java/io/browserservice/api/ws/push/SessionEventWatcher.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/SessionEventWatcher.java
@@ -1,0 +1,21 @@
+package io.browserservice.api.ws.push;
+
+/**
+ * One polling pass against the bound session. Implementations read driver state under a
+ * short lock, compare against their cached previous state, and emit zero or one event
+ * frame via the {@link EventBroadcaster}. Implementations must be safe to call repeatedly
+ * on the shared scheduler and must never block: lock contention means "skip this tick".
+ */
+public interface SessionEventWatcher {
+
+    /** Polling cadence in milliseconds. */
+    int periodMs();
+
+    /** Run one tick. Implementations should swallow recoverable errors and self-disable
+     *  on persistent ones (e.g. unsupported driver capabilities). */
+    void tick();
+
+    /** Optional cleanup hook called when this watcher's session has no remaining bound
+     *  WS connections (or has been reaped). Default: no-op. */
+    default void onStop() {}
+}

--- a/api/src/main/java/io/browserservice/api/ws/push/WatcherCoordinator.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/WatcherCoordinator.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -41,6 +42,13 @@ public class WatcherCoordinator {
     private final EngineProperties.WebSocketProps props;
 
     private final ConcurrentHashMap<UUID, List<ScheduledFuture<?>>> running = new ConcurrentHashMap<>();
+    /**
+     * Per-session lock serializing first-attach and last-detach against each other so a
+     * concurrent {@code last-detach + first-attach} interleaving can't cancel newly started
+     * futures (or leave orphans). Locks live for the lifetime of the JVM — bounded by the
+     * session-cap, so the leak is finite and small.
+     */
+    private final ConcurrentHashMap<UUID, ReentrantLock> sessionLocks = new ConcurrentHashMap<>();
 
     public WatcherCoordinator(WsSessionConnections connections,
                               SessionRegistry registry,
@@ -57,36 +65,48 @@ public class WatcherCoordinator {
     }
 
     public void onSessionAttached(UUID sessionId, Connection conn) {
-        boolean isFirst = connections.attach(sessionId, conn);
-        if (!isFirst) {
-            return;
+        ReentrantLock guard = sessionLocks.computeIfAbsent(sessionId, id -> new ReentrantLock());
+        guard.lock();
+        try {
+            boolean isFirst = connections.attach(sessionId, conn);
+            if (!isFirst) {
+                return;
+            }
+            SessionHandle handle = registry.find(sessionId).orElse(null);
+            if (handle == null) {
+                // Session vanished between bind and watcher start; clean up the entry we just added.
+                connections.detach(sessionId, conn);
+                return;
+            }
+            List<SessionEventWatcher> watchers = buildWatchers(sessionId, handle);
+            if (watchers.isEmpty()) {
+                return;
+            }
+            List<ScheduledFuture<?>> futures = new ArrayList<>(watchers.size());
+            for (SessionEventWatcher w : watchers) {
+                int period = Math.max(50, w.periodMs());
+                ScheduledFuture<?> f = scheduler.scheduleAtFixedRate(
+                        () -> safeTick(sessionId, w),
+                        period, period, TimeUnit.MILLISECONDS);
+                futures.add(f);
+            }
+            running.put(sessionId, futures);
+            log.debug("ws watchers started session={} count={}", sessionId, futures.size());
+        } finally {
+            guard.unlock();
         }
-        SessionHandle handle = registry.find(sessionId).orElse(null);
-        if (handle == null) {
-            // Session vanished between bind and watcher start; clean up the entry we just added.
-            connections.detach(sessionId, conn);
-            return;
-        }
-        List<SessionEventWatcher> watchers = buildWatchers(sessionId, handle);
-        if (watchers.isEmpty()) {
-            return;
-        }
-        List<ScheduledFuture<?>> futures = new ArrayList<>(watchers.size());
-        for (SessionEventWatcher w : watchers) {
-            int period = Math.max(50, w.periodMs());
-            ScheduledFuture<?> f = scheduler.scheduleAtFixedRate(
-                    () -> safeTick(sessionId, w),
-                    period, period, TimeUnit.MILLISECONDS);
-            futures.add(f);
-        }
-        running.put(sessionId, futures);
-        log.debug("ws watchers started session={} count={}", sessionId, futures.size());
     }
 
     public void onSessionDetached(UUID sessionId, Connection conn) {
-        boolean isLast = connections.detach(sessionId, conn);
-        if (isLast) {
-            stopWatchers(sessionId);
+        ReentrantLock guard = sessionLocks.computeIfAbsent(sessionId, id -> new ReentrantLock());
+        guard.lock();
+        try {
+            boolean isLast = connections.detach(sessionId, conn);
+            if (isLast) {
+                stopWatchers(sessionId);
+            }
+        } finally {
+            guard.unlock();
         }
     }
 

--- a/api/src/main/java/io/browserservice/api/ws/push/WatcherCoordinator.java
+++ b/api/src/main/java/io/browserservice/api/ws/push/WatcherCoordinator.java
@@ -1,0 +1,141 @@
+package io.browserservice.api.ws.push;
+
+import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.session.SessionRegistry;
+import io.browserservice.api.ws.Connection;
+import io.browserservice.api.ws.WsSessionConnections;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Owns the lifecycle of the per-session WS event watchers (alerts, console, navigation).
+ *
+ * <ul>
+ *   <li>Watchers start when the <strong>first</strong> WS connection binds to a session.</li>
+ *   <li>Watchers stop when the <strong>last</strong> connection unbinds, or when a tick
+ *       discovers the session has been removed from the registry (manual close, reaper).</li>
+ *   <li>All scheduling shares the single application-wide {@code ws-scheduler}; we never
+ *       allocate one scheduler per session.</li>
+ * </ul>
+ */
+@Component
+public class WatcherCoordinator {
+
+    private static final Logger log = LoggerFactory.getLogger(WatcherCoordinator.class);
+
+    private final WsSessionConnections connections;
+    private final SessionRegistry registry;
+    private final SessionLocks locks;
+    private final EventBroadcaster broadcaster;
+    private final ScheduledExecutorService scheduler;
+    private final EngineProperties.WebSocketProps props;
+
+    private final ConcurrentHashMap<UUID, List<ScheduledFuture<?>>> running = new ConcurrentHashMap<>();
+
+    public WatcherCoordinator(WsSessionConnections connections,
+                              SessionRegistry registry,
+                              SessionLocks locks,
+                              EventBroadcaster broadcaster,
+                              ScheduledExecutorService webSocketScheduler,
+                              EngineProperties props) {
+        this.connections = connections;
+        this.registry = registry;
+        this.locks = locks;
+        this.broadcaster = broadcaster;
+        this.scheduler = webSocketScheduler;
+        this.props = props.webSocket();
+    }
+
+    public void onSessionAttached(UUID sessionId, Connection conn) {
+        boolean isFirst = connections.attach(sessionId, conn);
+        if (!isFirst) {
+            return;
+        }
+        SessionHandle handle = registry.find(sessionId).orElse(null);
+        if (handle == null) {
+            // Session vanished between bind and watcher start; clean up the entry we just added.
+            connections.detach(sessionId, conn);
+            return;
+        }
+        List<SessionEventWatcher> watchers = buildWatchers(sessionId, handle);
+        if (watchers.isEmpty()) {
+            return;
+        }
+        List<ScheduledFuture<?>> futures = new ArrayList<>(watchers.size());
+        for (SessionEventWatcher w : watchers) {
+            int period = Math.max(50, w.periodMs());
+            ScheduledFuture<?> f = scheduler.scheduleAtFixedRate(
+                    () -> safeTick(sessionId, w),
+                    period, period, TimeUnit.MILLISECONDS);
+            futures.add(f);
+        }
+        running.put(sessionId, futures);
+        log.debug("ws watchers started session={} count={}", sessionId, futures.size());
+    }
+
+    public void onSessionDetached(UUID sessionId, Connection conn) {
+        boolean isLast = connections.detach(sessionId, conn);
+        if (isLast) {
+            stopWatchers(sessionId);
+        }
+    }
+
+    private List<SessionEventWatcher> buildWatchers(UUID sessionId, SessionHandle handle) {
+        long lockTimeout = props.watcherLockTimeoutMs();
+        List<SessionEventWatcher> out = new ArrayList<>(3);
+        if (props.alertPushEnabled()) {
+            out.add(new AlertWatcher(sessionId, handle, locks, broadcaster,
+                    props.alertPollMs(), lockTimeout));
+        }
+        if (props.consolePushEnabled()) {
+            out.add(new BrowserLogDrain(sessionId, handle, locks, broadcaster,
+                    props.consolePollMs(), lockTimeout));
+        }
+        if (props.navigationPushEnabled()) {
+            out.add(new NavigationWatcher(sessionId, handle, locks, broadcaster,
+                    props.navigationPollMs(), lockTimeout));
+        }
+        return out;
+    }
+
+    private void safeTick(UUID sessionId, SessionEventWatcher watcher) {
+        SessionHandle handle = registry.find(sessionId).orElse(null);
+        if (handle == null || handle.isClosed()) {
+            // Session has been removed (manual close or reaper). Self-cancel.
+            stopWatchers(sessionId);
+            return;
+        }
+        try {
+            watcher.tick();
+        } catch (Throwable t) {
+            log.debug("watcher tick threw session={} watcher={}: {}",
+                    sessionId, watcher.getClass().getSimpleName(), t.toString());
+        }
+    }
+
+    private void stopWatchers(UUID sessionId) {
+        List<ScheduledFuture<?>> futures = running.remove(sessionId);
+        if (futures == null) {
+            return;
+        }
+        for (ScheduledFuture<?> f : futures) {
+            f.cancel(false);
+        }
+        log.debug("ws watchers stopped session={}", sessionId);
+    }
+
+    /** Test/observability hook. */
+    public boolean isWatching(UUID sessionId) {
+        return running.containsKey(sessionId);
+    }
+}

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -47,6 +47,13 @@ browserservice:
     idle-close-seconds: 300
     outbound-buffer-ki-b: 64
     send-time-limit-ms: 10000
+    alert-push-enabled: true
+    alert-poll-ms: 250
+    console-push-enabled: true
+    console-poll-ms: 1000
+    navigation-push-enabled: true
+    navigation-poll-ms: 2000
+    watcher-lock-timeout-ms: 50
 
 management:
   endpoints:

--- a/api/src/test/java/io/browserservice/api/config/EngineConfigTest.java
+++ b/api/src/test/java/io/browserservice/api/config/EngineConfigTest.java
@@ -24,7 +24,7 @@ class EngineConfigTest {
                 new EngineProperties.AppiumProps("http://c/wd/hub", "ANDROID", "Pixel 7", 60000, 3),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "",
                         "", "", "", "", true, false, true),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
 
         EngineConfig cfg = new EngineConfig(props);
         cfg.seedConnectionHelper();
@@ -50,7 +50,7 @@ class EngineConfigTest {
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "",
                         "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
 
         new EngineConfig(props).seedConnectionHelper();
         // No exception, no URLs set — success is simply not throwing.
@@ -67,7 +67,7 @@ class EngineConfigTest {
                         "https://hub.browserstack.com/wd/hub", "user", "key",
                         "Windows", "11", "chrome", "126", "proj", "build", "name",
                         "Pixel 7", true, false, true),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
 
         new EngineConfig(props).seedConnectionHelper();
         assertThat(true).isTrue();
@@ -81,7 +81,7 @@ class EngineConfigTest {
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(true, "", "u", "k",
                         "", "", "", "", "", "", "", "", true, false, true),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
 
         new EngineConfig(props).seedConnectionHelper();
         assertThat(true).isTrue();

--- a/api/src/test/java/io/browserservice/api/service/AlertServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/AlertServiceTest.java
@@ -173,6 +173,6 @@ class AlertServiceTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/service/BrowserOperationsServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/BrowserOperationsServiceTest.java
@@ -623,6 +623,6 @@ class BrowserOperationsServiceTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/service/CaptureServiceMoreTest.java
+++ b/api/src/test/java/io/browserservice/api/service/CaptureServiceMoreTest.java
@@ -92,6 +92,6 @@ class CaptureServiceMoreTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/service/CaptureServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/CaptureServiceTest.java
@@ -185,6 +185,6 @@ class CaptureServiceTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/service/ElementOperationsServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/ElementOperationsServiceTest.java
@@ -236,6 +236,6 @@ class ElementOperationsServiceTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/service/ReadinessServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/ReadinessServiceTest.java
@@ -82,6 +82,6 @@ class ReadinessServiceTest {
                 new EngineProperties.SeleniumProps(selenium, 1000, 1000, 0, false, 0),
                 new EngineProperties.AppiumProps(appium, "", "", 1000, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
@@ -199,6 +199,6 @@ class SessionServiceTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/session/CaptureScreenshotCacheTest.java
+++ b/api/src/test/java/io/browserservice/api/session/CaptureScreenshotCacheTest.java
@@ -63,6 +63,6 @@ class CaptureScreenshotCacheTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/session/SessionLocksTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionLocksTest.java
@@ -88,6 +88,6 @@ class SessionLocksTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/session/SessionLocksTryDoWithLockTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionLocksTryDoWithLockTest.java
@@ -1,0 +1,66 @@
+package io.browserservice.api.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.looksee.browser.Browser;
+import com.looksee.browser.enums.BrowserEnvironment;
+import com.looksee.browser.enums.BrowserType;
+import io.browserservice.api.config.EngineProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SessionLocksTryDoWithLockTest {
+
+    private SessionLocks locks;
+    private SessionHandle handle;
+
+    @BeforeEach
+    void setUp() {
+        locks = new SessionLocks(new EngineProperties(
+                new EngineProperties.SessionProps(10, 60, 5, 5000),
+                new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
+                new EngineProperties.AppiumProps("", "", "", 0, 0),
+                new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50)));
+        handle = SessionHandle.desktop(Mockito.mock(Browser.class), BrowserType.CHROME, BrowserEnvironment.TEST,
+                Duration.ofSeconds(30), Duration.ofSeconds(60));
+    }
+
+    @Test
+    void doesNotRefreshIdleTtl() throws InterruptedException {
+        Instant before = handle.lastUsedAt();
+        Thread.sleep(10);
+
+        Optional<String> result = locks.tryDoWithLock(handle, 50, h -> "ok");
+
+        assertThat(result).contains("ok");
+        assertThat(handle.lastUsedAt()).as("watcher path must NOT bump lastUsedAt").isEqualTo(before);
+    }
+
+    @Test
+    void returnsEmptyOnContention() throws InterruptedException {
+        Thread holder = new Thread(() -> {
+            handle.lock().lock();
+            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
+            finally { handle.lock().unlock(); }
+        });
+        holder.setDaemon(true);
+        holder.start();
+        Thread.sleep(20);
+
+        Optional<String> result = locks.tryDoWithLock(handle, 20, h -> "ok");
+
+        assertThat(result).isEmpty();
+        holder.join(500);
+    }
+
+    @Test
+    void emptyOnNullWorkResult() {
+        Optional<String> result = locks.tryDoWithLock(handle, 50, h -> null);
+        assertThat(result).isEmpty();
+    }
+}

--- a/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
@@ -54,6 +54,6 @@ class SessionReaperTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/session/SessionRegistryTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionRegistryTest.java
@@ -122,6 +122,6 @@ class SessionRegistryTest {
                 new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
                 new EngineProperties.AppiumProps("", "", "", 0, 0),
                 new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
-                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000));
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
     }
 }

--- a/api/src/test/java/io/browserservice/api/ws/push/AlertWatcherTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/AlertWatcherTest.java
@@ -1,0 +1,127 @@
+package io.browserservice.api.ws.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.looksee.browser.Browser;
+import com.looksee.browser.enums.BrowserEnvironment;
+import com.looksee.browser.enums.BrowserType;
+import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.ws.dto.EventFrame;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.NoAlertPresentException;
+import org.openqa.selenium.WebDriver;
+
+class AlertWatcherTest {
+
+    private SessionLocks locks;
+    private EventBroadcaster broadcaster;
+    private SessionHandle handle;
+    private WebDriver driver;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        locks = new SessionLocks(new EngineProperties(
+                new EngineProperties.SessionProps(10, 60, 5, 5000),
+                new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
+                new EngineProperties.AppiumProps("", "", "", 0, 0),
+                new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50)));
+        broadcaster = mock(EventBroadcaster.class);
+        Browser browser = mock(Browser.class);
+        driver = mock(WebDriver.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
+        when(browser.getDriver()).thenReturn(driver);
+        handle = SessionHandle.desktop(browser, BrowserType.CHROME, BrowserEnvironment.TEST,
+                Duration.ofSeconds(30), Duration.ofSeconds(60));
+        sessionId = handle.id();
+    }
+
+    @Test
+    void firesOnRisingEdgeOnly() {
+        Alert alert = mock(Alert.class);
+        when(alert.getText()).thenReturn("are you sure?");
+        // tick 1: no alert; tick 2 & 3: alert present; tick 4: alert gone.
+        when(driver.switchTo().alert())
+                .thenThrow(new NoAlertPresentException("no"))
+                .thenReturn(alert)
+                .thenReturn(alert)
+                .thenThrow(new NoAlertPresentException("no"));
+
+        AlertWatcher watcher = new AlertWatcher(sessionId, handle, locks, broadcaster, 250, 50);
+        watcher.tick(); // no alert
+        watcher.tick(); // alert appears — emit
+        watcher.tick(); // still present — suppress
+        watcher.tick(); // gone
+
+        ArgumentCaptor<EventFrame> captor = ArgumentCaptor.forClass(EventFrame.class);
+        verify(broadcaster, times(1)).broadcast(eq(sessionId), captor.capture());
+        EventFrame frame = captor.getValue();
+        assertThat(frame.kind()).isEqualTo("alert.appeared");
+        assertThat(frame.type()).isEqualTo("event");
+    }
+
+    @Test
+    void doesNotFireWhenAlertPersists() {
+        Alert alert = mock(Alert.class);
+        when(driver.switchTo().alert()).thenReturn(alert);
+        when(alert.getText()).thenReturn("hi");
+
+        AlertWatcher watcher = new AlertWatcher(sessionId, handle, locks, broadcaster, 250, 50);
+        watcher.tick();
+        watcher.tick();
+        watcher.tick();
+
+        verify(broadcaster, times(1)).broadcast(eq(sessionId), any());
+    }
+
+    @Test
+    void doesNotRefreshIdleTtl() {
+        when(driver.switchTo().alert()).thenThrow(new NoAlertPresentException("no"));
+
+        java.time.Instant before = handle.lastUsedAt();
+        AlertWatcher watcher = new AlertWatcher(sessionId, handle, locks, broadcaster, 250, 50);
+        try { Thread.sleep(10); } catch (InterruptedException ignored) {}
+        watcher.tick();
+        watcher.tick();
+        java.time.Instant after = handle.lastUsedAt();
+
+        assertThat(after).isEqualTo(before);
+        verify(broadcaster, never()).broadcast(any(), any());
+    }
+
+    @Test
+    void skipsTickWhenLockUnavailable() {
+        when(driver.switchTo().alert()).thenThrow(new NoAlertPresentException("no"));
+        // Hold the session lock from another thread; the watcher's tryLock(50ms) will fail.
+        Thread holder = new Thread(() -> {
+            handle.lock().lock();
+            try { Thread.sleep(300); } catch (InterruptedException ignored) {}
+            finally { handle.lock().unlock(); }
+        });
+        holder.setDaemon(true);
+        holder.start();
+        try { Thread.sleep(20); } catch (InterruptedException ignored) {}
+
+        AlertWatcher watcher = new AlertWatcher(sessionId, handle, locks, broadcaster, 250, 20);
+        watcher.tick();
+
+        // Lock acquisition failed → no broadcast even though we'd expect rising-edge logic.
+        verify(broadcaster, never()).broadcast(any(), any());
+        try { holder.join(500); } catch (InterruptedException ignored) {}
+    }
+}

--- a/api/src/test/java/io/browserservice/api/ws/push/BrowserLogDrainTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/BrowserLogDrainTest.java
@@ -71,6 +71,28 @@ class BrowserLogDrainTest {
     }
 
     @Test
+    void broadcastsHappenAfterTheSessionLockIsReleased() {
+        LogEntry entry = new LogEntry(Level.WARNING, 1L, "x");
+        when(driverLogs.get(LogType.BROWSER)).thenReturn(new LogEntries(List.of(entry, entry)));
+
+        // Have the broadcaster try to acquire the session lock during each call. If the
+        // drain were broadcasting from inside its own lock, this would deadlock or fail.
+        java.util.concurrent.atomic.AtomicInteger acquired = new java.util.concurrent.atomic.AtomicInteger();
+        org.mockito.Mockito.doAnswer(inv -> {
+            if (handle.lock().tryLock()) {
+                try { acquired.incrementAndGet(); }
+                finally { handle.lock().unlock(); }
+            }
+            return null;
+        }).when(broadcaster).broadcast(eq(sessionId), any());
+
+        BrowserLogDrain drain = new BrowserLogDrain(sessionId, handle, locks, broadcaster, 1000, 50);
+        drain.tick();
+
+        assertThat(acquired.get()).as("broadcasts must run outside the session lock").isEqualTo(2);
+    }
+
+    @Test
     void selfDisablesOnUnsupportedCommand() {
         when(driverLogs.get(LogType.BROWSER))
                 .thenThrow(new UnsupportedCommandException("not supported"));

--- a/api/src/test/java/io/browserservice/api/ws/push/BrowserLogDrainTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/BrowserLogDrainTest.java
@@ -1,0 +1,88 @@
+package io.browserservice.api.ws.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.looksee.browser.Browser;
+import com.looksee.browser.enums.BrowserEnvironment;
+import com.looksee.browser.enums.BrowserType;
+import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.ws.dto.EventFrame;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openqa.selenium.UnsupportedCommandException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.logging.LogEntries;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.Logs;
+
+class BrowserLogDrainTest {
+
+    private SessionLocks locks;
+    private EventBroadcaster broadcaster;
+    private SessionHandle handle;
+    private WebDriver driver;
+    private Logs driverLogs;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        locks = new SessionLocks(new EngineProperties(
+                new EngineProperties.SessionProps(10, 60, 5, 5000),
+                new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
+                new EngineProperties.AppiumProps("", "", "", 0, 0),
+                new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50)));
+        broadcaster = mock(EventBroadcaster.class);
+        Browser browser = mock(Browser.class);
+        driver = mock(WebDriver.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
+        when(browser.getDriver()).thenReturn(driver);
+        driverLogs = driver.manage().logs();
+        handle = SessionHandle.desktop(browser, BrowserType.CHROME, BrowserEnvironment.TEST,
+                Duration.ofSeconds(30), Duration.ofSeconds(60));
+        sessionId = handle.id();
+    }
+
+    @Test
+    void emitsOneEventPerLogEntry() {
+        LogEntry e1 = new LogEntry(Level.WARNING, 100L, "boom");
+        LogEntry e2 = new LogEntry(Level.SEVERE, 200L, "splat");
+        when(driverLogs.get(LogType.BROWSER)).thenReturn(new LogEntries(List.of(e1, e2)));
+
+        BrowserLogDrain drain = new BrowserLogDrain(sessionId, handle, locks, broadcaster, 1000, 50);
+        drain.tick();
+
+        ArgumentCaptor<EventFrame> captor = ArgumentCaptor.forClass(EventFrame.class);
+        verify(broadcaster, times(2)).broadcast(eq(sessionId), captor.capture());
+        assertThat(captor.getAllValues()).allSatisfy(f -> assertThat(f.kind()).isEqualTo("console.log"));
+    }
+
+    @Test
+    void selfDisablesOnUnsupportedCommand() {
+        when(driverLogs.get(LogType.BROWSER))
+                .thenThrow(new UnsupportedCommandException("not supported"));
+
+        BrowserLogDrain drain = new BrowserLogDrain(sessionId, handle, locks, broadcaster, 1000, 50);
+        drain.tick();
+        drain.tick();
+        drain.tick();
+
+        assertThat(drain.isDisabled()).isTrue();
+        // After the first failure, subsequent ticks must not call the driver again.
+        verify(driverLogs, times(1)).get(LogType.BROWSER);
+        verify(broadcaster, times(0)).broadcast(any(), any());
+    }
+}

--- a/api/src/test/java/io/browserservice/api/ws/push/NavigationWatcherTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/NavigationWatcherTest.java
@@ -1,0 +1,83 @@
+package io.browserservice.api.ws.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.looksee.browser.Browser;
+import com.looksee.browser.enums.BrowserEnvironment;
+import com.looksee.browser.enums.BrowserType;
+import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.ws.dto.EventFrame;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.UnhandledAlertException;
+import org.openqa.selenium.WebDriver;
+
+class NavigationWatcherTest {
+
+    interface ScriptingDriver extends WebDriver, JavascriptExecutor {}
+
+    private SessionLocks locks;
+    private EventBroadcaster broadcaster;
+    private SessionHandle handle;
+    private ScriptingDriver driver;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        locks = new SessionLocks(new EngineProperties(
+                new EngineProperties.SessionProps(10, 60, 5, 5000),
+                new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
+                new EngineProperties.AppiumProps("", "", "", 0, 0),
+                new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50)));
+        broadcaster = mock(EventBroadcaster.class);
+        Browser browser = mock(Browser.class);
+        driver = mock(ScriptingDriver.class);
+        when(browser.getDriver()).thenReturn(driver);
+        handle = SessionHandle.desktop(browser, BrowserType.CHROME, BrowserEnvironment.TEST,
+                Duration.ofSeconds(30), Duration.ofSeconds(60));
+        sessionId = handle.id();
+    }
+
+    @Test
+    void emitsOnUrlChangeAndSuppressesIdenticalTicks() {
+        when(driver.executeScript(any(String.class)))
+                .thenReturn(List.of("https://example.com/a", "complete"))
+                .thenReturn(List.of("https://example.com/a", "complete"))   // same — suppress
+                .thenReturn(List.of("https://example.com/b", "loading"));
+
+        NavigationWatcher watcher = new NavigationWatcher(sessionId, handle, locks, broadcaster, 2000, 50);
+        watcher.tick();
+        watcher.tick();
+        watcher.tick();
+
+        ArgumentCaptor<EventFrame> captor = ArgumentCaptor.forClass(EventFrame.class);
+        verify(broadcaster, times(2)).broadcast(eq(sessionId), captor.capture());
+        assertThat(captor.getAllValues()).allSatisfy(f -> assertThat(f.kind()).isEqualTo("navigation.changed"));
+    }
+
+    @Test
+    void swallowsUnhandledAlert() {
+        when(driver.executeScript(any(String.class)))
+                .thenThrow(new UnhandledAlertException("alert blocking"));
+
+        NavigationWatcher watcher = new NavigationWatcher(sessionId, handle, locks, broadcaster, 2000, 50);
+        watcher.tick();
+
+        verify(broadcaster, never()).broadcast(any(), any());
+    }
+}

--- a/api/src/test/java/io/browserservice/api/ws/push/WatcherCoordinatorTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/WatcherCoordinatorTest.java
@@ -96,6 +96,39 @@ class WatcherCoordinatorTest {
     }
 
     @Test
+    void rapidAttachDetachInterleavingsConvergeCleanly() throws Exception {
+        // Hammer the coordinator with concurrent attach/detach pairs and assert the final
+        // state reconciles: empty connection set => no watchers, non-empty => watchers.
+        int rounds = 200;
+        Connection a = newConnection("alice-1");
+        Connection b = newConnection("alice-2");
+
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(2);
+        java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+        pool.submit(() -> {
+            try { start.await(); } catch (InterruptedException ignored) {}
+            for (int i = 0; i < rounds; i++) {
+                coordinator.onSessionAttached(sessionId, a);
+                coordinator.onSessionDetached(sessionId, a);
+            }
+        });
+        pool.submit(() -> {
+            try { start.await(); } catch (InterruptedException ignored) {}
+            for (int i = 0; i < rounds; i++) {
+                coordinator.onSessionAttached(sessionId, b);
+                coordinator.onSessionDetached(sessionId, b);
+            }
+        });
+        start.countDown();
+        pool.shutdown();
+        assertThat(pool.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS)).isTrue();
+
+        // Final state: no connections, no watchers.
+        assertThat(connections.isTracked(sessionId)).isFalse();
+        assertThat(coordinator.isWatching(sessionId)).isFalse();
+    }
+
+    @Test
     void attachToVanishedSessionIsCleanedUp() {
         Connection a = newConnection("alice-1");
         registry.remove(sessionId);

--- a/api/src/test/java/io/browserservice/api/ws/push/WatcherCoordinatorTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/WatcherCoordinatorTest.java
@@ -1,0 +1,126 @@
+package io.browserservice.api.ws.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.looksee.browser.Browser;
+import com.looksee.browser.enums.BrowserEnvironment;
+import com.looksee.browser.enums.BrowserType;
+import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionLocks;
+import io.browserservice.api.session.SessionRegistry;
+import io.browserservice.api.ws.CallerId;
+import io.browserservice.api.ws.Connection;
+import io.browserservice.api.ws.WsSessionConnections;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoAlertPresentException;
+import org.openqa.selenium.WebDriver;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
+
+class WatcherCoordinatorTest {
+
+    private SessionRegistry registry;
+    private SessionLocks locks;
+    private WsSessionConnections connections;
+    private EventBroadcaster broadcaster;
+    private ScheduledExecutorService scheduler;
+    private WatcherCoordinator coordinator;
+
+    private SessionHandle handle;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        EngineProperties props = props();
+        registry = new SessionRegistry(props);
+        locks = new SessionLocks(props);
+        connections = new WsSessionConnections();
+        broadcaster = mock(EventBroadcaster.class);
+        scheduler = Executors.newScheduledThreadPool(1, r -> {
+            Thread t = new Thread(r, "test-ws-scheduler");
+            t.setDaemon(true);
+            return t;
+        });
+        coordinator = new WatcherCoordinator(connections, registry, locks, broadcaster, scheduler, props);
+
+        Browser browser = mock(Browser.class);
+        WebDriver driver = mock(WebDriver.class, org.mockito.Mockito.RETURNS_DEEP_STUBS);
+        when(browser.getDriver()).thenReturn(driver);
+        when(driver.switchTo().alert()).thenThrow(new NoAlertPresentException("no"));
+        handle = SessionHandle.desktop(browser, BrowserType.CHROME, BrowserEnvironment.TEST,
+                Duration.ofSeconds(30), Duration.ofSeconds(60));
+        sessionId = handle.id();
+        registry.acquirePermit();
+        registry.register(handle);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    @Test
+    void firstAttachStartsWatchersAndLastDetachStopsThem() {
+        Connection a = newConnection("alice-1");
+        Connection b = newConnection("alice-2");
+
+        coordinator.onSessionAttached(sessionId, a);
+        assertThat(coordinator.isWatching(sessionId)).isTrue();
+
+        coordinator.onSessionAttached(sessionId, b);
+        assertThat(coordinator.isWatching(sessionId)).isTrue();
+
+        coordinator.onSessionDetached(sessionId, a);
+        // Still has b bound — must keep watching.
+        assertThat(coordinator.isWatching(sessionId)).isTrue();
+
+        coordinator.onSessionDetached(sessionId, b);
+        assertThat(coordinator.isWatching(sessionId)).isFalse();
+    }
+
+    @Test
+    void detachWithoutPriorAttachIsHarmless() {
+        Connection a = newConnection("alice-1");
+        coordinator.onSessionDetached(sessionId, a);
+        assertThat(coordinator.isWatching(sessionId)).isFalse();
+    }
+
+    @Test
+    void attachToVanishedSessionIsCleanedUp() {
+        Connection a = newConnection("alice-1");
+        registry.remove(sessionId);
+
+        coordinator.onSessionAttached(sessionId, a);
+
+        assertThat(coordinator.isWatching(sessionId)).isFalse();
+        assertThat(connections.isTracked(sessionId)).isFalse();
+    }
+
+    private Connection newConnection(String id) {
+        WebSocketSession ws = mock(WebSocketSession.class);
+        when(ws.isOpen()).thenReturn(true);
+        ConcurrentWebSocketSessionDecorator out = new ConcurrentWebSocketSessionDecorator(ws, 1000, 64 * 1024);
+        return new Connection(CallerId.parse("alice"), id, out,
+                Executors.newSingleThreadExecutor(),
+                new Semaphore(8));
+    }
+
+    private static EngineProperties props() {
+        return new EngineProperties(
+                new EngineProperties.SessionProps(10, 60, 5, 5000),
+                new EngineProperties.SeleniumProps("", 0, 0, 0, false, 0),
+                new EngineProperties.AppiumProps("", "", "", 0, 0),
+                new EngineProperties.BrowserStackProps(false, "", "", "", "", "", "", "", "", "", "", "", false, false, false),
+                new EngineProperties.WebSocketProps("/v1/ws/sessions", 32, 300, 64, 10000, true, 250, true, 1000, true, 2000, 50));
+    }
+}


### PR DESCRIPTION
Implements **issue #7** (WS-B in the WebSocket epic #5). Builds on WS-A (#9, merged).

## Summary

Bound WebSocket clients now receive unsolicited browser-side events without polling. Three event kinds are in scope:

- `alert.appeared` — rising-edge poll of `driver.switchTo().alert()`
- `console.log` — drains `driver.manage().logs().get(BROWSER)`
- `navigation.changed` — polls `[location.href, document.readyState]`

WS-A's request/response surface is unchanged. Events ride on the existing per-connection `ConcurrentWebSocketSessionDecorator`, so pushed events and command responses serialize cleanly on the wire.

## Protocol additions

```jsonc
{ "type": "event", "kind": "alert.appeared",
  "data": { "text": "Are you sure?" } }
{ "type": "event", "kind": "console.log",
  "data": { "level": "WARNING", "message": "...", "ts": 1234 } }
{ "type": "event", "kind": "navigation.changed",
  "data": { "url": "https://...", "ready_state": "complete" } }
```

## Temporal contract preserved

- Watchers acquire the session lock through a new `SessionLocks.tryDoWithLock(timeoutMs, work)` variant that **does not** call `SessionHandle.touch()`. Server-driven instrumentation must not refresh idle TTL — only real user commands keep a session alive.
- Default watcher lock timeout is **50 ms** (configurable). On contention the tick is skipped — user commands never block on a watcher.

## Lifecycle

- Watchers start when the **first** WS connection binds to a session, stop when the **last** one unbinds.
- Coordinated by a single `WatcherCoordinator` backed by a per-session `WsSessionConnections` registry.
- Tick self-cancels if the session has been removed (manual close, reaper) — no reaper-side hook needed.
- WS-A's private `ScheduledExecutorService` is lifted to a top-level `WebSocketBeans` `@Bean` so the handler and the coordinator share one scheduler.

## Driver compatibility

- `BrowserLogDrain` self-disables on `UnsupportedCommandException` / "not implemented" / "command not found" / "unsupported" `WebDriverException`, with a single INFO log. Chrome sessions started without `goog:loggingPrefs` return an empty list — silently fine.
- `NavigationWatcher` swallows `UnhandledAlertException`; the alert watcher surfaces blocking alerts.
- `AlertWatcher` emits exactly one `alert.appeared` per rising edge — none on subsequent ticks while present, none after dismissal.

## Refactor

- `AlertService.peekAlert(SessionHandle)` extracted as a public helper so REST (under `doWithLock`) and the WS `AlertWatcher` (under `tryDoWithLock`) share one detection path. **`AlertService.getAlert(UUID)` REST behavior is byte-for-byte unchanged** (existing tests cover it).

## Config

`EngineProperties.WebSocketProps` gains seven knobs (defaults shown):

| key | default |
| --- | --- |
| `alert-push-enabled` | `true` |
| `alert-poll-ms` | `250` |
| `console-push-enabled` | `true` |
| `console-poll-ms` | `1000` |
| `navigation-push-enabled` | `true` |
| `navigation-poll-ms` | `2000` |
| `watcher-lock-timeout-ms` | `50` |

Mirrored in `application.yaml`.

## Tests

| Test class | Coverage |
| --- | --- |
| `AlertWatcherTest` | rising-edge, persistence suppression, lock contention skip, no idle-TTL refresh |
| `BrowserLogDrainTest` | one event per `LogEntry`; self-disable on `UnsupportedCommandException`; subsequent ticks don't call driver |
| `NavigationWatcherTest` | emit on change, suppress identical, swallow `UnhandledAlertException` |
| `WatcherCoordinatorTest` | first-attach starts, last-detach stops, multi-connection tracking, vanished-session cleanup |
| `SessionLocksTryDoWithLockTest` | empty on contention, successful run does not bump `lastUsedAt` |

**224 / 224 API tests green** (210 baseline + 14 new).

## Out of scope

- Binary frames for screenshots — WS-C (#8).
- DOM mutation / CDP streaming.
- Per-event subscriptions / filters from the client. WS-B sends every enabled event to every bound connection. A subscription model is a follow-up if requested.
- Adding `goog:loggingPrefs` to driver creation. Documented as a known limitation; can land later in `DriverFactory`.

## Test plan

- [ ] `mvn -am -pl api test` — all 224 green.
- [ ] Smoke: open WS, `session.create`, navigate to a page that calls `alert('hi')` → receive both the navigate response **and** an unsolicited `alert.appeared` event within ~250 ms.
- [ ] `script.execute` of `console.warn(...)` (Chrome session with `goog:loggingPrefs`) → `console.log` event within ~1 s.
- [ ] Click an internal link → `navigation.changed` event.
- [ ] Set `BROWSERSERVICE_WEB_SOCKET_ALERT_PUSH_ENABLED=false`, restart → no alert events.
- [ ] Watcher polling does not refresh idle TTL: leave the connection idle except for watchers; reaper still evicts at the configured idle TTL.

https://claude.ai/code/session_01PfxQMP1wnoUVBw7H32dZbP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfxQMP1wnoUVBw7H32dZbP)_