### PR TITLE
feat(api): add Postgres tracking for browser session lifecycle

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,6 +46,23 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
@@ -76,6 +93,16 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>selenium</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/api/src/main/java/io/browserservice/api/persistence/BrowserSessionEntity.java
+++ b/api/src/main/java/io/browserservice/api/persistence/BrowserSessionEntity.java
@@ -1,0 +1,104 @@
+package io.browserservice.api.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "browser_sessions")
+public class BrowserSessionEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "browser_type", nullable = false, length = 32)
+    private String browserType;
+
+    @Column(name = "environment", nullable = false, length = 32)
+    private String environment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private Status status;
+
+    @Column(name = "is_mobile", nullable = false)
+    private boolean mobile;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "last_used_at", nullable = false)
+    private Instant lastUsedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "closed_at")
+    private Instant closedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "closed_reason", length = 32)
+    private ClosedReason closedReason;
+
+    @Column(name = "idle_ttl_secs", nullable = false)
+    private int idleTtlSecs;
+
+    @Column(name = "absolute_ttl_secs", nullable = false)
+    private int absoluteTtlSecs;
+
+    protected BrowserSessionEntity() {
+    }
+
+    public BrowserSessionEntity(UUID id, String browserType, String environment, Status status,
+                                boolean mobile, Instant createdAt, Instant lastUsedAt, Instant expiresAt,
+                                int idleTtlSecs, int absoluteTtlSecs) {
+        this.id = id;
+        this.browserType = browserType;
+        this.environment = environment;
+        this.status = status;
+        this.mobile = mobile;
+        this.createdAt = createdAt;
+        this.lastUsedAt = lastUsedAt;
+        this.expiresAt = expiresAt;
+        this.idleTtlSecs = idleTtlSecs;
+        this.absoluteTtlSecs = absoluteTtlSecs;
+    }
+
+    public UUID getId() { return id; }
+    public String getBrowserType() { return browserType; }
+    public String getEnvironment() { return environment; }
+    public Status getStatus() { return status; }
+    public boolean isMobile() { return mobile; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getLastUsedAt() { return lastUsedAt; }
+    public Instant getExpiresAt() { return expiresAt; }
+    public Instant getClosedAt() { return closedAt; }
+    public ClosedReason getClosedReason() { return closedReason; }
+    public int getIdleTtlSecs() { return idleTtlSecs; }
+    public int getAbsoluteTtlSecs() { return absoluteTtlSecs; }
+
+    public void setStatus(Status status) { this.status = status; }
+    public void setLastUsedAt(Instant lastUsedAt) { this.lastUsedAt = lastUsedAt; }
+    public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
+    public void setClosedAt(Instant closedAt) { this.closedAt = closedAt; }
+    public void setClosedReason(ClosedReason closedReason) { this.closedReason = closedReason; }
+
+    public enum Status {
+        ACTIVE,
+        CLOSED,
+        EXPIRED
+    }
+
+    public enum ClosedReason {
+        CLIENT,
+        REAPED_IDLE,
+        REAPED_ABSOLUTE,
+        ERROR
+    }
+}

--- a/api/src/main/java/io/browserservice/api/persistence/BrowserSessionRepository.java
+++ b/api/src/main/java/io/browserservice/api/persistence/BrowserSessionRepository.java
@@ -1,0 +1,12 @@
+package io.browserservice.api.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BrowserSessionRepository extends JpaRepository<BrowserSessionEntity, UUID> {
+
+    List<BrowserSessionEntity> findByStatus(BrowserSessionEntity.Status status);
+}

--- a/api/src/main/java/io/browserservice/api/persistence/BrowserSessionTracker.java
+++ b/api/src/main/java/io/browserservice/api/persistence/BrowserSessionTracker.java
@@ -1,0 +1,135 @@
+package io.browserservice.api.persistence;
+
+import io.browserservice.api.persistence.BrowserSessionEntity.ClosedReason;
+import io.browserservice.api.persistence.BrowserSessionEntity.Status;
+import io.browserservice.api.session.SessionHandle;
+import io.browserservice.api.session.SessionRegistry;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class BrowserSessionTracker {
+
+    private static final Logger log = LoggerFactory.getLogger(BrowserSessionTracker.class);
+
+    private final BrowserSessionRepository repository;
+    private final SessionRegistry registry;
+
+    public BrowserSessionTracker(BrowserSessionRepository repository, SessionRegistry registry) {
+        this.repository = repository;
+        this.registry = registry;
+    }
+
+    @Transactional
+    public void recordCreate(SessionHandle handle) {
+        BrowserSessionEntity entity = new BrowserSessionEntity(
+                handle.id(),
+                handle.browserType().name(),
+                handle.environment().name(),
+                Status.ACTIVE,
+                handle.isMobile(),
+                handle.createdAt(),
+                handle.lastUsedAt(),
+                handle.expiresAt(),
+                (int) handle.idleTtl().toSeconds(),
+                (int) handle.absoluteTtl().toSeconds());
+        repository.save(entity);
+    }
+
+    @Transactional
+    public void recordClientClose(UUID id) {
+        try {
+            updateClosed(id, Status.CLOSED, ClosedReason.CLIENT);
+        } catch (RuntimeException e) {
+            log.warn("failed to record client close for session {}: {}", id, e.toString());
+        }
+    }
+
+    @Transactional
+    public void recordReap(UUID id, ClosedReason reason) {
+        try {
+            updateClosed(id, Status.EXPIRED, reason);
+        } catch (RuntimeException e) {
+            log.warn("failed to record reap for session {}: {}", id, e.toString());
+        }
+    }
+
+    @Scheduled(fixedDelay = 30_000)
+    @Transactional
+    public void flushLastUsed() {
+        List<SessionHandle> snapshot = registry.snapshot();
+        if (snapshot.isEmpty()) {
+            return;
+        }
+        Map<UUID, SessionHandle> live = new HashMap<>(snapshot.size());
+        for (SessionHandle h : snapshot) {
+            if (!h.isClosed()) {
+                live.put(h.id(), h);
+            }
+        }
+        if (live.isEmpty()) {
+            return;
+        }
+        try {
+            for (BrowserSessionEntity entity : repository.findAllById(live.keySet())) {
+                if (entity.getStatus() != Status.ACTIVE) {
+                    continue;
+                }
+                SessionHandle h = live.get(entity.getId());
+                entity.setLastUsedAt(h.lastUsedAt());
+                entity.setExpiresAt(h.expiresAt());
+            }
+        } catch (RuntimeException e) {
+            log.warn("failed to flush last_used_at for {} sessions: {}", live.size(), e.toString());
+        }
+    }
+
+    // Sessions left ACTIVE in the DB by a prior process can never be operated on again — the
+    // in-memory WebDriver they reference is gone. Mark them EXPIRED on startup so the table
+    // reflects reality.
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void recoverOrphanedActiveSessions() {
+        try {
+            Instant now = Instant.now();
+            List<BrowserSessionEntity> orphans = repository.findByStatus(Status.ACTIVE);
+            if (orphans.isEmpty()) {
+                return;
+            }
+            for (BrowserSessionEntity entity : orphans) {
+                entity.setStatus(Status.EXPIRED);
+                entity.setClosedReason(ClosedReason.ERROR);
+                entity.setClosedAt(now);
+            }
+            log.info("marked {} orphaned ACTIVE browser_sessions rows as EXPIRED on startup", orphans.size());
+        } catch (RuntimeException e) {
+            log.warn("failed to recover orphaned ACTIVE browser_sessions: {}", e.toString());
+        }
+    }
+
+    private void updateClosed(UUID id, Status status, ClosedReason reason) {
+        Optional<BrowserSessionEntity> maybe = repository.findById(id);
+        if (maybe.isEmpty()) {
+            log.warn("no browser_sessions row found for id={} while recording {}", id, status);
+            return;
+        }
+        BrowserSessionEntity entity = maybe.get();
+        if (entity.getStatus() != Status.ACTIVE) {
+            return;
+        }
+        entity.setStatus(status);
+        entity.setClosedReason(reason);
+        entity.setClosedAt(Instant.now());
+    }
+}

--- a/api/src/main/java/io/browserservice/api/service/SessionService.java
+++ b/api/src/main/java/io/browserservice/api/service/SessionService.java
@@ -10,6 +10,7 @@ import io.browserservice.api.dto.SessionListResponse;
 import io.browserservice.api.dto.SessionResponse;
 import io.browserservice.api.dto.SessionStateResponse;
 import io.browserservice.api.dto.Viewport;
+import io.browserservice.api.persistence.BrowserSessionTracker;
 import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
@@ -32,14 +33,17 @@ public class SessionService {
     private final SessionRegistry registry;
     private final SessionLocks locks;
     private final DriverFactory drivers;
+    private final BrowserSessionTracker tracker;
     private final Duration defaultIdleTtl;
     private final Duration absoluteTtl;
 
     public SessionService(SessionRegistry registry, SessionLocks locks,
-                          DriverFactory drivers, EngineProperties props) {
+                          DriverFactory drivers, BrowserSessionTracker tracker,
+                          EngineProperties props) {
         this.registry = registry;
         this.locks = locks;
         this.drivers = drivers;
+        this.tracker = tracker;
         this.defaultIdleTtl = Duration.ofSeconds(props.session().idleTtlSeconds());
         this.absoluteTtl = Duration.ofSeconds(props.session().absoluteTtlSeconds());
     }
@@ -58,6 +62,7 @@ public class SessionService {
                 Browser browser = drivers.createDesktop(req.browserType(), req.environment());
                 handle = SessionHandle.desktop(browser, req.browserType(), req.environment(), idleTtl, absoluteTtl);
             }
+            tracker.recordCreate(handle);
             registry.register(handle);
             log.info("created session id={} browserType={} environment={}",
                     handle.id(), handle.browserType(), handle.environment());
@@ -84,6 +89,7 @@ public class SessionService {
     public void close(UUID id) {
         SessionHandle handle = registry.get(id);
         registry.remove(handle.id());
+        tracker.recordClientClose(handle.id());
         log.info("closed session id={}", id);
     }
 

--- a/api/src/main/java/io/browserservice/api/service/SessionService.java
+++ b/api/src/main/java/io/browserservice/api/service/SessionService.java
@@ -50,11 +50,11 @@ public class SessionService {
 
     public SessionResponse create(CreateSessionRequest req) {
         registry.acquirePermit();
+        SessionHandle handle = null;
         try {
             Duration idleTtl = req.idleTtlSeconds() == null
                     ? defaultIdleTtl
                     : Duration.ofSeconds(req.idleTtlSeconds());
-            SessionHandle handle;
             if (req.browserType().isMobile()) {
                 MobileDevice device = drivers.createMobile(req.browserType(), req.environment());
                 handle = SessionHandle.mobile(device, req.browserType(), req.environment(), idleTtl, absoluteTtl);
@@ -68,6 +68,9 @@ public class SessionService {
                     handle.id(), handle.browserType(), handle.environment());
             return toSummary(handle);
         } catch (RuntimeException e) {
+            if (handle != null) {
+                handle.closeOnce();
+            }
             registry.releasePermit();
             throw e;
         }

--- a/api/src/main/java/io/browserservice/api/session/SessionReaper.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionReaper.java
@@ -1,5 +1,7 @@
 package io.browserservice.api.session;
 
+import io.browserservice.api.persistence.BrowserSessionEntity.ClosedReason;
+import io.browserservice.api.persistence.BrowserSessionTracker;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,9 +14,11 @@ public class SessionReaper {
     private static final Logger log = LoggerFactory.getLogger(SessionReaper.class);
 
     private final SessionRegistry registry;
+    private final BrowserSessionTracker tracker;
 
-    public SessionReaper(SessionRegistry registry) {
+    public SessionReaper(SessionRegistry registry, BrowserSessionTracker tracker) {
         this.registry = registry;
+        this.tracker = tracker;
     }
 
     @Scheduled(fixedDelay = 10_000)
@@ -24,11 +28,20 @@ public class SessionReaper {
             if (handle.isClosed() || !handle.isExpired(now)) {
                 continue;
             }
+            ClosedReason reason = reasonFor(handle, now);
             if (registry.remove(handle.id())) {
-                log.info("reaped session id={} browserType={} idleTtl={}s absoluteTtl={}s",
-                        handle.id(), handle.browserType(),
+                tracker.recordReap(handle.id(), reason);
+                log.info("reaped session id={} browserType={} reason={} idleTtl={}s absoluteTtl={}s",
+                        handle.id(), handle.browserType(), reason,
                         handle.idleTtl().toSeconds(), handle.absoluteTtl().toSeconds());
             }
         }
+    }
+
+    private static ClosedReason reasonFor(SessionHandle handle, Instant now) {
+        if (now.isAfter(handle.createdAt().plus(handle.absoluteTtl()))) {
+            return ClosedReason.REAPED_ABSOLUTE;
+        }
+        return ClosedReason.REAPED_IDLE;
     }
 }

--- a/api/src/main/java/io/browserservice/api/session/SessionReaper.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionReaper.java
@@ -28,7 +28,7 @@ public class SessionReaper {
             if (handle.isClosed() || !handle.isExpired(now)) {
                 continue;
             }
-            ClosedReason reason = reasonFor(handle, now);
+            ClosedReason reason = reasonFor(handle);
             if (registry.remove(handle.id())) {
                 tracker.recordReap(handle.id(), reason);
                 log.info("reaped session id={} browserType={} reason={} idleTtl={}s absoluteTtl={}s",
@@ -38,10 +38,11 @@ public class SessionReaper {
         }
     }
 
-    private static ClosedReason reasonFor(SessionHandle handle, Instant now) {
-        if (now.isAfter(handle.createdAt().plus(handle.absoluteTtl()))) {
-            return ClosedReason.REAPED_ABSOLUTE;
-        }
-        return ClosedReason.REAPED_IDLE;
+    private static ClosedReason reasonFor(SessionHandle handle) {
+        Instant idleDeadline = handle.lastUsedAt().plus(handle.idleTtl());
+        Instant absoluteDeadline = handle.createdAt().plus(handle.absoluteTtl());
+        return absoluteDeadline.isBefore(idleDeadline)
+                ? ClosedReason.REAPED_ABSOLUTE
+                : ClosedReason.REAPED_IDLE;
     }
 }

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -13,6 +13,22 @@ spring:
     default-property-inclusion: non_null
     serialization:
       write-dates-as-timestamps: false
+  datasource:
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/browser_service}
+    username: ${DATABASE_USERNAME:browser_service}
+    password: ${DATABASE_PASSWORD:browser_service}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+        format_sql: false
+    open-in-view: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
 
 browserservice:
   session:

--- a/api/src/main/resources/db/migration/V1__create_browser_sessions.sql
+++ b/api/src/main/resources/db/migration/V1__create_browser_sessions.sql
@@ -1,0 +1,18 @@
+CREATE TABLE browser_sessions (
+    id                UUID         PRIMARY KEY,
+    browser_type      VARCHAR(32)  NOT NULL,
+    environment       VARCHAR(32)  NOT NULL,
+    status            VARCHAR(16)  NOT NULL,
+    is_mobile         BOOLEAN      NOT NULL,
+    created_at        TIMESTAMPTZ  NOT NULL,
+    last_used_at      TIMESTAMPTZ  NOT NULL,
+    expires_at        TIMESTAMPTZ  NOT NULL,
+    closed_at         TIMESTAMPTZ,
+    closed_reason     VARCHAR(32),
+    idle_ttl_secs     INTEGER      NOT NULL,
+    absolute_ttl_secs INTEGER      NOT NULL
+);
+
+CREATE INDEX idx_browser_sessions_status         ON browser_sessions (status);
+CREATE INDEX idx_browser_sessions_created_at     ON browser_sessions (created_at DESC);
+CREATE INDEX idx_browser_sessions_status_expires ON browser_sessions (status, expires_at);

--- a/api/src/test/java/io/browserservice/api/controller/ControllerHttpTest.java
+++ b/api/src/test/java/io/browserservice/api/controller/ControllerHttpTest.java
@@ -92,6 +92,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
+@org.springframework.test.context.ActiveProfiles("test")
 @TestPropertySource(properties = {
         "browserservice.selenium.urls=http://localhost:4444/wd/hub",
         "browserservice.appium.urls=",

--- a/api/src/test/java/io/browserservice/api/integration/SeleniumGridIT.java
+++ b/api/src/test/java/io/browserservice/api/integration/SeleniumGridIT.java
@@ -37,6 +37,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
+@org.springframework.test.context.ActiveProfiles("test")
 @Testcontainers
 class SeleniumGridIT {
 

--- a/api/src/test/java/io/browserservice/api/openapi/SpecExportTest.java
+++ b/api/src/test/java/io/browserservice/api/openapi/SpecExportTest.java
@@ -31,6 +31,7 @@ import org.yaml.snakeyaml.Yaml;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
+@org.springframework.test.context.ActiveProfiles("test")
 @TestPropertySource(properties = {
         "browserservice.selenium.urls=http://localhost:4444/wd/hub",
         "browserservice.appium.urls=",

--- a/api/src/test/java/io/browserservice/api/persistence/BrowserSessionRepositoryIT.java
+++ b/api/src/test/java/io/browserservice/api/persistence/BrowserSessionRepositoryIT.java
@@ -1,0 +1,120 @@
+package io.browserservice.api.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.browserservice.api.persistence.BrowserSessionEntity.ClosedReason;
+import io.browserservice.api.persistence.BrowserSessionEntity.Status;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class BrowserSessionRepositoryIT {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>(DockerImageName.parse("postgres:17-alpine"))
+                    .withDatabaseName("browser_service")
+                    .withUsername("browser_service")
+                    .withPassword("browser_service");
+
+    @DynamicPropertySource
+    static void datasourceProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.flyway.enabled", () -> "true");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    }
+
+    @Autowired
+    private BrowserSessionRepository repository;
+
+    @Test
+    void insertAndFindActiveSession() {
+        BrowserSessionEntity entity = newActive();
+
+        repository.saveAndFlush(entity);
+        repository.findById(entity.getId()).ifPresentOrElse(found -> {
+            assertThat(found.getStatus()).isEqualTo(Status.ACTIVE);
+            assertThat(found.getBrowserType()).isEqualTo("CHROME");
+            assertThat(found.getEnvironment()).isEqualTo("TEST");
+            assertThat(found.isMobile()).isFalse();
+            assertThat(found.getIdleTtlSecs()).isEqualTo(300);
+            assertThat(found.getAbsoluteTtlSecs()).isEqualTo(1800);
+        }, () -> {
+            throw new AssertionError("expected entity not found");
+        });
+    }
+
+    @Test
+    void updateToClosedRecordsReason() {
+        BrowserSessionEntity entity = repository.saveAndFlush(newActive());
+
+        entity.setStatus(Status.CLOSED);
+        entity.setClosedReason(ClosedReason.CLIENT);
+        entity.setClosedAt(Instant.now());
+        repository.saveAndFlush(entity);
+
+        BrowserSessionEntity found = repository.findById(entity.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(Status.CLOSED);
+        assertThat(found.getClosedReason()).isEqualTo(ClosedReason.CLIENT);
+        assertThat(found.getClosedAt()).isNotNull();
+    }
+
+    @Test
+    void findByStatusReturnsOnlyMatching() {
+        BrowserSessionEntity active = repository.saveAndFlush(newActive());
+        BrowserSessionEntity closed = newActive();
+        closed.setStatus(Status.CLOSED);
+        closed.setClosedReason(ClosedReason.CLIENT);
+        closed.setClosedAt(Instant.now());
+        repository.saveAndFlush(closed);
+
+        List<BrowserSessionEntity> activeRows = repository.findByStatus(Status.ACTIVE);
+        assertThat(activeRows).extracting(BrowserSessionEntity::getId).contains(active.getId());
+        assertThat(activeRows).extracting(BrowserSessionEntity::getId).doesNotContain(closed.getId());
+    }
+
+    @Test
+    void expiredReapWritesReapedReason() {
+        BrowserSessionEntity entity = repository.saveAndFlush(newActive());
+
+        entity.setStatus(Status.EXPIRED);
+        entity.setClosedReason(ClosedReason.REAPED_ABSOLUTE);
+        entity.setClosedAt(Instant.now());
+        repository.saveAndFlush(entity);
+
+        BrowserSessionEntity found = repository.findById(entity.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(Status.EXPIRED);
+        assertThat(found.getClosedReason()).isEqualTo(ClosedReason.REAPED_ABSOLUTE);
+    }
+
+    private static BrowserSessionEntity newActive() {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        return new BrowserSessionEntity(
+                UUID.randomUUID(),
+                "CHROME",
+                "TEST",
+                Status.ACTIVE,
+                false,
+                now,
+                now,
+                now.plusSeconds(300),
+                300,
+                1800);
+    }
+}

--- a/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
@@ -18,7 +18,9 @@ import io.browserservice.api.dto.SessionStateResponse;
 import io.browserservice.api.error.SessionCapExceededException;
 import io.browserservice.api.error.SessionNotFoundException;
 import io.browserservice.api.error.UpstreamUnavailableException;
+import io.browserservice.api.persistence.BrowserSessionTracker;
 import io.browserservice.api.session.DriverFactory;
+import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
 import io.browserservice.api.session.SessionRegistry;
 import java.util.UUID;
@@ -33,6 +35,7 @@ class SessionServiceTest {
     private SessionRegistry registry;
     private SessionLocks locks;
     private DriverFactory drivers;
+    private BrowserSessionTracker tracker;
     private SessionService service;
 
     @BeforeEach
@@ -41,7 +44,8 @@ class SessionServiceTest {
         registry = new SessionRegistry(props);
         locks = new SessionLocks(props);
         drivers = mock(DriverFactory.class);
-        service = new SessionService(registry, locks, drivers, props);
+        tracker = mock(BrowserSessionTracker.class);
+        service = new SessionService(registry, locks, drivers, tracker, props);
     }
 
     @Test
@@ -168,6 +172,31 @@ class SessionServiceTest {
 
         verify(browser).close();
         assertThat(registry.size()).isZero();
+    }
+
+    @Test
+    void createRecordsSessionInTracker() {
+        Browser browser = mockBrowserWithDriver();
+        when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+
+        SessionResponse created = service.create(new CreateSessionRequest(
+                BrowserType.CHROME, BrowserEnvironment.TEST, null));
+
+        org.mockito.ArgumentCaptor<SessionHandle> captor = org.mockito.ArgumentCaptor.forClass(SessionHandle.class);
+        verify(tracker).recordCreate(captor.capture());
+        assertThat(captor.getValue().id()).isEqualTo(created.sessionId());
+    }
+
+    @Test
+    void closeRecordsClientCloseInTracker() {
+        Browser browser = mockBrowserWithDriver();
+        when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+
+        SessionResponse created = service.create(new CreateSessionRequest(
+                BrowserType.CHROME, BrowserEnvironment.TEST, null));
+        service.close(created.sessionId());
+
+        verify(tracker).recordClientClose(created.sessionId());
     }
 
     @Test

--- a/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
@@ -100,6 +100,22 @@ class SessionServiceTest {
     }
 
     @Test
+    void trackerFailureClosesBrowserAndReleasesPermit() {
+        Browser browser = mockBrowserWithDriver();
+        when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+        org.mockito.Mockito.doThrow(new RuntimeException("db down"))
+                .when(tracker).recordCreate(org.mockito.ArgumentMatchers.any(SessionHandle.class));
+
+        assertThatThrownBy(() ->
+                service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null)))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(browser).close();
+        assertThat(registry.availablePermits()).isEqualTo(2);
+        assertThat(registry.size()).isZero();
+    }
+
+    @Test
     void createEnforcesCap() {
         Browser browser = mockBrowserWithDriver();
         when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);

--- a/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
@@ -1,13 +1,19 @@
 package io.browserservice.api.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.looksee.browser.Browser;
 import com.looksee.browser.enums.BrowserEnvironment;
 import com.looksee.browser.enums.BrowserType;
 import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.persistence.BrowserSessionEntity.ClosedReason;
+import io.browserservice.api.persistence.BrowserSessionTracker;
 import java.time.Duration;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class SessionReaperTest {
@@ -15,6 +21,7 @@ class SessionReaperTest {
     @Test
     void reapClosesExpiredHandlesAndLeavesActiveOnes() throws Exception {
         SessionRegistry registry = new SessionRegistry(props());
+        BrowserSessionTracker tracker = mock(BrowserSessionTracker.class);
 
         SessionHandle expired = SessionHandle.desktop(mock(Browser.class), BrowserType.CHROME,
                 BrowserEnvironment.TEST, Duration.ofMillis(1), Duration.ofSeconds(60));
@@ -28,24 +35,46 @@ class SessionReaperTest {
 
         Thread.sleep(10);
 
-        new SessionReaper(registry).reap();
+        new SessionReaper(registry, tracker).reap();
 
         assertThat(registry.find(expired.id())).isEmpty();
         assertThat(registry.find(active.id())).isPresent();
+        verify(tracker).recordReap(expired.id(), ClosedReason.REAPED_IDLE);
+        verify(tracker, never()).recordReap(active.id(), ClosedReason.REAPED_IDLE);
+        verify(tracker, never()).recordReap(active.id(), ClosedReason.REAPED_ABSOLUTE);
+    }
+
+    @Test
+    void reapDistinguishesAbsoluteTtlExpiry() throws Exception {
+        SessionRegistry registry = new SessionRegistry(props());
+        BrowserSessionTracker tracker = mock(BrowserSessionTracker.class);
+
+        SessionHandle absoluteExpired = SessionHandle.desktop(mock(Browser.class), BrowserType.CHROME,
+                BrowserEnvironment.TEST, Duration.ofSeconds(60), Duration.ofMillis(1));
+        registry.acquirePermit();
+        registry.register(absoluteExpired);
+
+        Thread.sleep(10);
+
+        new SessionReaper(registry, tracker).reap();
+
+        verify(tracker).recordReap(absoluteExpired.id(), ClosedReason.REAPED_ABSOLUTE);
     }
 
     @Test
     void reapSkipsAlreadyClosedHandles() {
         SessionRegistry registry = new SessionRegistry(props());
+        BrowserSessionTracker tracker = mock(BrowserSessionTracker.class);
         SessionHandle handle = SessionHandle.desktop(mock(Browser.class), BrowserType.CHROME,
                 BrowserEnvironment.TEST, Duration.ofSeconds(60), Duration.ofSeconds(60));
         registry.acquirePermit();
         registry.register(handle);
         handle.closeOnce();
 
-        new SessionReaper(registry).reap();
+        new SessionReaper(registry, tracker).reap();
 
         assertThat(registry.find(handle.id())).isEmpty();
+        verify(tracker, never()).recordReap(any(UUID.class), any(ClosedReason.class));
     }
 
     private static EngineProperties props() {

--- a/api/src/test/java/io/browserservice/api/ws/SessionWebSocketHandlerTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/SessionWebSocketHandlerTest.java
@@ -59,6 +59,7 @@ import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@org.springframework.test.context.ActiveProfiles("test")
 @TestPropertySource(properties = {
         "browserservice.selenium.urls=http://localhost:4444/wd/hub",
         "browserservice.appium.urls=",

--- a/api/src/test/resources/application-test.yaml
+++ b/api/src/test/resources/application-test.yaml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:browser_service_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  flyway:
+    enabled: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: browser-service-postgres
+    environment:
+      POSTGRES_DB: browser_service
+      POSTGRES_USER: browser_service
+      POSTGRES_PASSWORD: browser_service
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U browser_service -d browser_service"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

Adds a Postgres database (latest stable, **Postgres 17**) and a `browser_sessions` table that tracks every browser session through its lifecycle. The in-memory `SessionRegistry` stays as the source of truth for live `WebDriver` operations; Postgres becomes the durable record for tracking and observability.

- **Schema**: `browser_sessions` with `status` (`ACTIVE`/`CLOSED`/`EXPIRED`), `closed_reason` (`CLIENT`/`REAPED_IDLE`/`REAPED_ABSOLUTE`/`ERROR`), TTL columns, and indexes on `status`, `created_at`, and `(status, expires_at)`.
- **Write-through tracking** via a single new `BrowserSessionTracker` component:
  - `SessionService.create()` inserts an `ACTIVE` row.
  - `SessionService.close()` flips it to `CLOSED` / `CLIENT`.
  - `SessionReaper.reap()` flips it to `EXPIRED` / `REAPED_IDLE` or `REAPED_ABSOLUTE` based on which TTL fired.
  - Scheduled 30s flush of `last_used_at` and `expires_at` for live sessions.
  - `ApplicationReadyEvent` sweep marks orphaned `ACTIVE` rows as `EXPIRED` / `ERROR` on startup (their in-memory `WebDriver` is gone).
- **Stack**: Spring Data JPA + Flyway + pgjdbc (versions managed by the existing Spring Boot 3.3.5 BOM).
- **Local dev**: new `docker-compose.yml` with `postgres:17-alpine`, named volume, and healthcheck.
- **Tests**:
  - `BrowserSessionRepositoryIT` — `@DataJpaTest` against Testcontainers `postgres:17-alpine`.
  - `SessionServiceTest` / `SessionReaperTest` — assert tracker invocations with the right `ClosedReason`.
  - `application-test.yaml` (H2 in PG-compat mode, Flyway disabled, `ddl-auto=create-drop`) plus `@ActiveProfiles("test")` on existing `@SpringBootTest` classes so they don't require a live Postgres.

## Files

| Action | Path |
|---|---|
| Create | `api/src/main/java/io/browserservice/api/persistence/BrowserSessionEntity.java` |
| Create | `api/src/main/java/io/browserservice/api/persistence/BrowserSessionRepository.java` |
| Create | `api/src/main/java/io/browserservice/api/persistence/BrowserSessionTracker.java` |
| Create | `api/src/main/resources/db/migration/V1__create_browser_sessions.sql` |
| Create | `docker-compose.yml` |
| Create | `api/src/test/java/io/browserservice/api/persistence/BrowserSessionRepositoryIT.java` |
| Create | `api/src/test/resources/application-test.yaml` |
| Modify | `api/pom.xml` (deps) |
| Modify | `api/src/main/java/io/browserservice/api/service/SessionService.java` |
| Modify | `api/src/main/java/io/browserservice/api/session/SessionReaper.java` |
| Modify | `api/src/main/resources/application.yaml` (datasource + jpa + flyway) |
| Modify | existing `@SpringBootTest` classes (`@ActiveProfiles("test")`) |

## Test plan

- [x] `mvn -pl api -am test` — 234 api tests + 287 engine tests, all green.
- [ ] `mvn -pl api -am verify` — runs `BrowserSessionRepositoryIT` and `SeleniumGridIT` against Docker (CI environment).
- [ ] End-to-end smoke:
  - `docker compose up -d postgres && mvn -pl api spring-boot:run` — Flyway applies `V1__create_browser_sessions.sql`.
  - `POST /v1/sessions` → row appears with `status=ACTIVE`.
  - `DELETE /v1/sessions/{id}` → same row updated to `status=CLOSED`, `closed_reason=CLIENT`.
  - Create a session with `idle_ttl_seconds=2`, wait > reaper interval (10s) → `status=EXPIRED`, `closed_reason=REAPED_IDLE`.
  - Restart while a session is `ACTIVE` → row flips to `EXPIRED` / `closed_reason=ERROR` on startup.

https://claude.ai/code/session_012soABppwfWZx7RVhv3YN4m

---
_Generated by [Claude Code](https://claude.ai/code/session_012soABppwfWZx7RVhv3YN4m)_