### PR TITLE
[Caller-Id 2/5 + 3/5] Domain owner + controllers require X-Caller-Id

### DIFF
--- a/api/src/main/java/io/browserservice/api/config/OpenApiConfig.java
+++ b/api/src/main/java/io/browserservice/api/config/OpenApiConfig.java
@@ -15,11 +15,19 @@ import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
 import java.util.List;
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
+
+  static {
+    // Hide CallerId from springdoc's parameter introspection. It is resolved out of the
+    // X-Caller-Id header by CallerIdArgumentResolver, not from request parameters; without this
+    // springdoc would treat each controller's CallerId argument as a query parameter.
+    SpringDocUtils.getConfig().addRequestWrapperToIgnore(CallerId.class);
+  }
 
   @Bean
   public OpenAPI browserServiceOpenApi() {

--- a/api/src/main/java/io/browserservice/api/controller/AlertsController.java
+++ b/api/src/main/java/io/browserservice/api/controller/AlertsController.java
@@ -4,6 +4,7 @@ import io.browserservice.api.dto.AlertRespondRequest;
 import io.browserservice.api.dto.AlertStateResponse;
 import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.service.AlertService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -43,8 +44,8 @@ public class AlertsController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public AlertStateResponse getAlert(@PathVariable UUID id) {
-    return service.getAlert(id);
+  public AlertStateResponse getAlert(@PathVariable UUID id, CallerId caller) {
+    return service.getAlert(id, caller);
   }
 
   @PostMapping("/alert/respond")
@@ -57,7 +58,8 @@ public class AlertsController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public void respond(@PathVariable UUID id, @Valid @RequestBody AlertRespondRequest req) {
-    service.respond(id, req);
+  public void respond(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody AlertRespondRequest req) {
+    service.respond(id, caller, req);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/CaptureController.java
+++ b/api/src/main/java/io/browserservice/api/controller/CaptureController.java
@@ -4,6 +4,7 @@ import io.browserservice.api.dto.CaptureRequest;
 import io.browserservice.api.dto.CaptureResponse;
 import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.service.CaptureService;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.CaptureScreenshotCache;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -52,8 +53,8 @@ public class CaptureController {
         description = "Upstream unavailable",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public CaptureResponse capture(@Valid @RequestBody CaptureRequest req) {
-    return service.capture(req);
+  public CaptureResponse capture(@Valid @RequestBody CaptureRequest req, CallerId caller) {
+    return service.capture(req, caller);
   }
 
   @GetMapping(value = "/{captureId}/screenshot", produces = MediaType.IMAGE_PNG_VALUE)
@@ -69,8 +70,8 @@ public class CaptureController {
         description = "Capture expired",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public ResponseEntity<byte[]> getScreenshot(@PathVariable UUID captureId) {
-    CaptureScreenshotCache.CaptureEntry entry = service.fetchScreenshot(captureId);
+  public ResponseEntity<byte[]> getScreenshot(@PathVariable UUID captureId, CallerId caller) {
+    CaptureScreenshotCache.CaptureEntry entry = service.fetchScreenshot(captureId, caller);
     return ResponseEntity.ok().contentType(MediaType.IMAGE_PNG).body(entry.pngBytes());
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/DomController.java
+++ b/api/src/main/java/io/browserservice/api/controller/DomController.java
@@ -3,6 +3,7 @@ package io.browserservice.api.controller;
 import io.browserservice.api.dto.DomRemoveRequest;
 import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.service.BrowserOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -50,7 +51,8 @@ public class DomController {
         description = "Mobile session (desktop required)",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public void remove(@PathVariable UUID id, @Valid @RequestBody DomRemoveRequest req) {
-    service.removeDom(id, req);
+  public void remove(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody DomRemoveRequest req) {
+    service.removeDom(id, caller, req);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/ElementsController.java
+++ b/api/src/main/java/io/browserservice/api/controller/ElementsController.java
@@ -5,6 +5,7 @@ import io.browserservice.api.dto.ElementStateResponse;
 import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.dto.FindElementRequest;
 import io.browserservice.api.service.ElementOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -44,8 +45,8 @@ public class ElementsController {
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   public ElementStateResponse find(
-      @PathVariable UUID id, @Valid @RequestBody FindElementRequest req) {
-    return service.find(id, req);
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody FindElementRequest req) {
+    return service.find(id, caller, req);
   }
 
   @PostMapping("/action")
@@ -64,7 +65,8 @@ public class ElementsController {
         description = "Mobile session (desktop required)",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public void action(@PathVariable UUID id, @Valid @RequestBody ElementActionRequest req) {
-    service.action(id, req);
+  public void action(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody ElementActionRequest req) {
+    service.action(id, caller, req);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/MouseController.java
+++ b/api/src/main/java/io/browserservice/api/controller/MouseController.java
@@ -3,6 +3,7 @@ package io.browserservice.api.controller;
 import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.dto.MouseMoveRequest;
 import io.browserservice.api.service.BrowserOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -48,7 +49,8 @@ public class MouseController {
         description = "Mobile session (desktop required)",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public void move(@PathVariable UUID id, @Valid @RequestBody MouseMoveRequest req) {
-    service.moveMouse(id, req);
+  public void move(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody MouseMoveRequest req) {
+    service.moveMouse(id, caller, req);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/NavigationController.java
+++ b/api/src/main/java/io/browserservice/api/controller/NavigationController.java
@@ -6,6 +6,7 @@ import io.browserservice.api.dto.NavigateResponse;
 import io.browserservice.api.dto.PageSourceResponse;
 import io.browserservice.api.dto.PageStatusResponse;
 import io.browserservice.api.service.BrowserOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -48,8 +49,9 @@ public class NavigationController {
         description = "Upstream error",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public NavigateResponse navigate(@PathVariable UUID id, @Valid @RequestBody NavigateRequest req) {
-    return service.navigate(id, req);
+  public NavigateResponse navigate(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody NavigateRequest req) {
+    return service.navigate(id, caller, req);
   }
 
   @GetMapping("/source")
@@ -63,8 +65,8 @@ public class NavigationController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public PageSourceResponse source(@PathVariable UUID id) {
-    return service.getSource(id);
+  public PageSourceResponse source(@PathVariable UUID id, CallerId caller) {
+    return service.getSource(id, caller);
   }
 
   @GetMapping("/status")
@@ -80,7 +82,7 @@ public class NavigationController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public PageStatusResponse status(@PathVariable UUID id) {
-    return service.getStatus(id);
+  public PageStatusResponse status(@PathVariable UUID id, CallerId caller) {
+    return service.getStatus(id, caller);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/ScreenshotsController.java
+++ b/api/src/main/java/io/browserservice/api/controller/ScreenshotsController.java
@@ -7,6 +7,7 @@ import io.browserservice.api.dto.ScreenshotBase64Response;
 import io.browserservice.api.dto.ScreenshotRequest;
 import io.browserservice.api.service.BrowserOperationsService;
 import io.browserservice.api.service.ElementOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -60,8 +61,8 @@ public class ScreenshotsController {
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   public ResponseEntity<?> capture(
-      @PathVariable UUID id, @Valid @RequestBody ScreenshotRequest req) {
-    byte[] pngBytes = browserOps.pageScreenshot(id, req.strategy());
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody ScreenshotRequest req) {
+    byte[] pngBytes = browserOps.pageScreenshot(id, caller, req.strategy());
     return respond(pngBytes, req.encoding());
   }
 
@@ -79,8 +80,8 @@ public class ScreenshotsController {
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   public ResponseEntity<?> captureElement(
-      @PathVariable UUID id, @Valid @RequestBody ElementScreenshotRequest req) {
-    byte[] pngBytes = elementOps.elementScreenshot(id, req);
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody ElementScreenshotRequest req) {
+    byte[] pngBytes = elementOps.elementScreenshot(id, caller, req);
     return respond(pngBytes, req.encoding());
   }
 

--- a/api/src/main/java/io/browserservice/api/controller/ScriptController.java
+++ b/api/src/main/java/io/browserservice/api/controller/ScriptController.java
@@ -4,6 +4,7 @@ import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.dto.ExecuteRequest;
 import io.browserservice.api.dto.ExecuteResponse;
 import io.browserservice.api.service.BrowserOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -40,7 +41,8 @@ public class ScriptController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public ExecuteResponse execute(@PathVariable UUID id, @Valid @RequestBody ExecuteRequest req) {
-    return service.executeScript(id, req);
+  public ExecuteResponse execute(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody ExecuteRequest req) {
+    return service.executeScript(id, caller, req);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/ScrollController.java
+++ b/api/src/main/java/io/browserservice/api/controller/ScrollController.java
@@ -4,6 +4,7 @@ import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.dto.ScrollOffset;
 import io.browserservice.api.dto.ScrollRequest;
 import io.browserservice.api.service.BrowserOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -44,7 +45,8 @@ public class ScrollController {
         description = "Session or element handle not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public ScrollOffset scroll(@PathVariable UUID id, @Valid @RequestBody ScrollRequest req) {
-    return service.scroll(id, req);
+  public ScrollOffset scroll(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody ScrollRequest req) {
+    return service.scroll(id, caller, req);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/SessionsController.java
+++ b/api/src/main/java/io/browserservice/api/controller/SessionsController.java
@@ -6,6 +6,7 @@ import io.browserservice.api.dto.SessionListResponse;
 import io.browserservice.api.dto.SessionResponse;
 import io.browserservice.api.dto.SessionStateResponse;
 import io.browserservice.api.service.SessionService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,8 +57,8 @@ public class SessionsController {
         description = "Upstream hub unavailable",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public SessionResponse create(@Valid @RequestBody CreateSessionRequest req) {
-    return sessionService.create(req);
+  public SessionResponse create(@Valid @RequestBody CreateSessionRequest req, CallerId caller) {
+    return sessionService.create(req, caller);
   }
 
   @GetMapping
@@ -68,8 +69,8 @@ public class SessionsController {
         description = "Session list",
         content = @Content(schema = @Schema(implementation = SessionListResponse.class)))
   })
-  public SessionListResponse list() {
-    return sessionService.list();
+  public SessionListResponse list(CallerId caller) {
+    return sessionService.list(caller);
   }
 
   @GetMapping("/{id}")
@@ -84,8 +85,8 @@ public class SessionsController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public SessionStateResponse get(@PathVariable UUID id) {
-    return sessionService.describe(id);
+  public SessionStateResponse get(@PathVariable UUID id, CallerId caller) {
+    return sessionService.describe(id, caller);
   }
 
   @DeleteMapping("/{id}")
@@ -98,7 +99,7 @@ public class SessionsController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public void delete(@PathVariable UUID id) {
-    sessionService.close(id);
+  public void delete(@PathVariable UUID id, CallerId caller) {
+    sessionService.close(id, caller);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/TouchController.java
+++ b/api/src/main/java/io/browserservice/api/controller/TouchController.java
@@ -3,6 +3,7 @@ package io.browserservice.api.controller;
 import io.browserservice.api.dto.ElementTouchRequest;
 import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.service.ElementOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -46,7 +47,8 @@ public class TouchController {
         description = "Desktop session (mobile required)",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public void touch(@PathVariable UUID id, @Valid @RequestBody ElementTouchRequest req) {
-    service.touch(id, req);
+  public void touch(
+      @PathVariable UUID id, CallerId caller, @Valid @RequestBody ElementTouchRequest req) {
+    service.touch(id, caller, req);
   }
 }

--- a/api/src/main/java/io/browserservice/api/controller/ViewportController.java
+++ b/api/src/main/java/io/browserservice/api/controller/ViewportController.java
@@ -3,6 +3,7 @@ package io.browserservice.api.controller;
 import io.browserservice.api.dto.ErrorResponse;
 import io.browserservice.api.dto.ViewportStateResponse;
 import io.browserservice.api.service.BrowserOperationsService;
+import io.browserservice.api.session.CallerId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -37,7 +38,7 @@ public class ViewportController {
         description = "Session not found",
         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public ViewportStateResponse viewport(@PathVariable UUID id) {
-    return service.getViewport(id);
+  public ViewportStateResponse viewport(@PathVariable UUID id, CallerId caller) {
+    return service.getViewport(id, caller);
   }
 }

--- a/api/src/main/java/io/browserservice/api/service/AlertService.java
+++ b/api/src/main/java/io/browserservice/api/service/AlertService.java
@@ -3,9 +3,9 @@ package io.browserservice.api.service;
 import com.looksee.browser.enums.AlertChoice;
 import io.browserservice.api.dto.AlertRespondRequest;
 import io.browserservice.api.dto.AlertStateResponse;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
-import io.browserservice.api.session.SessionRegistry;
 import java.util.UUID;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.NoAlertPresentException;
@@ -15,23 +15,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class AlertService {
 
-  private final SessionRegistry registry;
+  private final SessionService sessionService;
   private final SessionLocks locks;
 
-  public AlertService(SessionRegistry registry, SessionLocks locks) {
-    this.registry = registry;
+  public AlertService(SessionService sessionService, SessionLocks locks) {
+    this.sessionService = sessionService;
     this.locks = locks;
   }
 
-  public AlertStateResponse getAlert(UUID sessionId) {
-    SessionHandle handle = registry.get(sessionId);
+  public AlertStateResponse getAlert(UUID sessionId, CallerId caller) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(handle, AlertService::peekAlert);
   }
 
   /**
    * Reads the current alert state assuming the caller already holds the session lock. Used by both
-   * the user-facing {@link #getAlert(UUID)} (under {@code doWithLock}) and by the WS {@code
-   * AlertWatcher} (under {@code tryDoWithLock}, which must not refresh idle TTL).
+   * the user-facing {@link #getAlert(UUID, CallerId)} (under {@code doWithLock}) and by the WS
+   * {@code AlertWatcher} (under {@code tryDoWithLock}, which must not refresh idle TTL).
    */
   public static AlertStateResponse peekAlert(SessionHandle handle) {
     Alert alert = findAlert(handle.driver());
@@ -41,8 +41,8 @@ public class AlertService {
     return new AlertStateResponse(true, safeAlertText(alert));
   }
 
-  public void respond(UUID sessionId, AlertRespondRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public void respond(UUID sessionId, CallerId caller, AlertRespondRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     locks.doWithLockVoid(
         handle,
         h -> {

--- a/api/src/main/java/io/browserservice/api/service/BrowserOperationsService.java
+++ b/api/src/main/java/io/browserservice/api/service/BrowserOperationsService.java
@@ -20,9 +20,9 @@ import io.browserservice.api.dto.Viewport;
 import io.browserservice.api.dto.ViewportStateResponse;
 import io.browserservice.api.error.DesktopSessionRequiredException;
 import io.browserservice.api.error.ValidationFailedException;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
-import io.browserservice.api.session.SessionRegistry;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.UUID;
@@ -37,16 +37,16 @@ import org.springframework.stereotype.Service;
 @Service
 public class BrowserOperationsService {
 
-  private final SessionRegistry registry;
+  private final SessionService sessionService;
   private final SessionLocks locks;
 
-  public BrowserOperationsService(SessionRegistry registry, SessionLocks locks) {
-    this.registry = registry;
+  public BrowserOperationsService(SessionService sessionService, SessionLocks locks) {
+    this.sessionService = sessionService;
     this.locks = locks;
   }
 
-  public NavigateResponse navigate(UUID sessionId, NavigateRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public NavigateResponse navigate(UUID sessionId, CallerId caller, NavigateRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {
@@ -67,8 +67,8 @@ public class BrowserOperationsService {
         });
   }
 
-  public PageSourceResponse getSource(UUID sessionId) {
-    SessionHandle handle = registry.get(sessionId);
+  public PageSourceResponse getSource(UUID sessionId, CallerId caller) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {
@@ -77,8 +77,8 @@ public class BrowserOperationsService {
         });
   }
 
-  public PageStatusResponse getStatus(UUID sessionId) {
-    SessionHandle handle = registry.get(sessionId);
+  public PageStatusResponse getStatus(UUID sessionId, CallerId caller) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {
@@ -93,8 +93,8 @@ public class BrowserOperationsService {
         });
   }
 
-  public ViewportStateResponse getViewport(UUID sessionId) {
-    SessionHandle handle = registry.get(sessionId);
+  public ViewportStateResponse getViewport(UUID sessionId, CallerId caller) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {
@@ -109,8 +109,8 @@ public class BrowserOperationsService {
         });
   }
 
-  public ScrollOffset scroll(UUID sessionId, ScrollRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public ScrollOffset scroll(UUID sessionId, CallerId caller, ScrollRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {
@@ -124,8 +124,8 @@ public class BrowserOperationsService {
   }
 
   public byte[] pageScreenshot(
-      UUID sessionId, io.browserservice.api.dto.ScreenshotStrategy strategy) {
-    SessionHandle handle = registry.get(sessionId);
+      UUID sessionId, CallerId caller, io.browserservice.api.dto.ScreenshotStrategy strategy) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {
@@ -139,8 +139,8 @@ public class BrowserOperationsService {
         });
   }
 
-  public void removeDom(UUID sessionId, DomRemoveRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public void removeDom(UUID sessionId, CallerId caller, DomRemoveRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     if (handle.isMobile()) {
       throw new DesktopSessionRequiredException();
     }
@@ -161,8 +161,8 @@ public class BrowserOperationsService {
         });
   }
 
-  public void moveMouse(UUID sessionId, MouseMoveRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public void moveMouse(UUID sessionId, CallerId caller, MouseMoveRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     if (handle.isMobile()) {
       throw new DesktopSessionRequiredException();
     }
@@ -182,8 +182,8 @@ public class BrowserOperationsService {
         });
   }
 
-  public ExecuteResponse executeScript(UUID sessionId, ExecuteRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public ExecuteResponse executeScript(UUID sessionId, CallerId caller, ExecuteRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {

--- a/api/src/main/java/io/browserservice/api/service/CaptureService.java
+++ b/api/src/main/java/io/browserservice/api/service/CaptureService.java
@@ -12,6 +12,7 @@ import io.browserservice.api.dto.PngEncoding;
 import io.browserservice.api.dto.Rect;
 import io.browserservice.api.dto.ScreenshotStrategy;
 import io.browserservice.api.error.UpstreamUnavailableException;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.CaptureScreenshotCache;
 import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionHandle;
@@ -56,7 +57,7 @@ public class CaptureService {
     this.absoluteTtl = Duration.ofSeconds(props.session().absoluteTtlSeconds());
   }
 
-  public CaptureResponse capture(CaptureRequest req) {
+  public CaptureResponse capture(CaptureRequest req, CallerId caller) {
     BrowserEnvironment env =
         req.environment() == null ? BrowserEnvironment.TEST : req.environment();
     ScreenshotStrategy strategy =
@@ -70,10 +71,11 @@ public class CaptureService {
     try {
       if (req.browserType().isMobile()) {
         MobileDevice device = drivers.createMobile(req.browserType(), env);
-        handle = SessionHandle.mobile(device, req.browserType(), env, idleTtl, absoluteTtl);
+        handle = SessionHandle.mobile(device, caller, req.browserType(), env, idleTtl, absoluteTtl);
       } else {
         Browser browser = drivers.createDesktop(req.browserType(), env);
-        handle = SessionHandle.desktop(browser, req.browserType(), env, idleTtl, absoluteTtl);
+        handle =
+            SessionHandle.desktop(browser, caller, req.browserType(), env, idleTtl, absoluteTtl);
       }
       registry.register(handle);
 
@@ -212,7 +214,12 @@ public class CaptureService {
         null, "/v1/capture/" + captureId + "/screenshot", width, height);
   }
 
-  public CaptureScreenshotCache.CaptureEntry fetchScreenshot(UUID captureId) {
+  /**
+   * Fetches a deferred capture screenshot. The {@code caller} is threaded through for symmetry with
+   * other endpoints; cross-caller cache isolation (rejecting a fetch when the caller did not author
+   * the capture) is a deferred follow-up.
+   */
+  public CaptureScreenshotCache.CaptureEntry fetchScreenshot(UUID captureId, CallerId caller) {
     return cache.get(captureId);
   }
 }

--- a/api/src/main/java/io/browserservice/api/service/ElementOperationsService.java
+++ b/api/src/main/java/io/browserservice/api/service/ElementOperationsService.java
@@ -11,9 +11,9 @@ import io.browserservice.api.dto.Rect;
 import io.browserservice.api.error.DesktopSessionRequiredException;
 import io.browserservice.api.error.MobileSessionRequiredException;
 import io.browserservice.api.error.UpstreamUnavailableException;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
-import io.browserservice.api.session.SessionRegistry;
 import java.awt.image.BufferedImage;
 import java.util.Map;
 import java.util.UUID;
@@ -24,16 +24,16 @@ import org.springframework.stereotype.Service;
 @Service
 public class ElementOperationsService {
 
-  private final SessionRegistry registry;
+  private final SessionService sessionService;
   private final SessionLocks locks;
 
-  public ElementOperationsService(SessionRegistry registry, SessionLocks locks) {
-    this.registry = registry;
+  public ElementOperationsService(SessionService sessionService, SessionLocks locks) {
+    this.sessionService = sessionService;
     this.locks = locks;
   }
 
-  public ElementStateResponse find(UUID sessionId, FindElementRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public ElementStateResponse find(UUID sessionId, CallerId caller, FindElementRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {
@@ -58,8 +58,8 @@ public class ElementOperationsService {
         });
   }
 
-  public void action(UUID sessionId, ElementActionRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public void action(UUID sessionId, CallerId caller, ElementActionRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     if (handle.isMobile()) {
       throw new DesktopSessionRequiredException();
     }
@@ -72,8 +72,8 @@ public class ElementOperationsService {
         });
   }
 
-  public void touch(UUID sessionId, ElementTouchRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public void touch(UUID sessionId, CallerId caller, ElementTouchRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     if (!handle.isMobile()) {
       throw new MobileSessionRequiredException();
     }
@@ -86,8 +86,8 @@ public class ElementOperationsService {
         });
   }
 
-  public byte[] elementScreenshot(UUID sessionId, ElementScreenshotRequest req) {
-    SessionHandle handle = registry.get(sessionId);
+  public byte[] elementScreenshot(UUID sessionId, CallerId caller, ElementScreenshotRequest req) {
+    SessionHandle handle = sessionService.requireOwner(sessionId, caller);
     return locks.doWithLock(
         handle,
         h -> {

--- a/api/src/main/java/io/browserservice/api/service/SessionService.java
+++ b/api/src/main/java/io/browserservice/api/service/SessionService.java
@@ -9,7 +9,9 @@ import io.browserservice.api.dto.SessionListResponse;
 import io.browserservice.api.dto.SessionResponse;
 import io.browserservice.api.dto.SessionStateResponse;
 import io.browserservice.api.dto.Viewport;
+import io.browserservice.api.error.SessionForbiddenException;
 import io.browserservice.api.persistence.BrowserSessionTracker;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
@@ -50,7 +52,7 @@ public class SessionService {
     this.absoluteTtl = Duration.ofSeconds(props.session().absoluteTtlSeconds());
   }
 
-  public SessionResponse create(CreateSessionRequest req) {
+  public SessionResponse create(CreateSessionRequest req, CallerId caller) {
     registry.acquirePermit();
     SessionHandle handle = null;
     try {
@@ -60,12 +62,12 @@ public class SessionService {
         MobileDevice device = drivers.createMobile(req.browserType(), req.environment());
         handle =
             SessionHandle.mobile(
-                device, req.browserType(), req.environment(), idleTtl, absoluteTtl);
+                device, caller, req.browserType(), req.environment(), idleTtl, absoluteTtl);
       } else {
         Browser browser = drivers.createDesktop(req.browserType(), req.environment());
         handle =
             SessionHandle.desktop(
-                browser, req.browserType(), req.environment(), idleTtl, absoluteTtl);
+                browser, caller, req.browserType(), req.environment(), idleTtl, absoluteTtl);
       }
       tracker.recordCreate(handle);
       registry.register(handle);
@@ -84,25 +86,38 @@ public class SessionService {
     }
   }
 
-  public SessionListResponse list() {
+  public SessionListResponse list(CallerId caller) {
     List<SessionResponse> items =
         registry.snapshot().stream()
-            .filter(h -> !h.isClosed())
+            .filter(h -> !h.isClosed() && h.owner().equals(caller))
             .map(SessionService::toSummary)
             .toList();
     return new SessionListResponse(items);
   }
 
-  public SessionStateResponse describe(UUID id) {
-    SessionHandle handle = registry.get(id);
+  public SessionStateResponse describe(UUID id, CallerId caller) {
+    SessionHandle handle = requireOwner(id, caller);
     return locks.doWithLock(handle, this::toStateLocked);
   }
 
-  public void close(UUID id) {
-    SessionHandle handle = registry.get(id);
+  public void close(UUID id, CallerId caller) {
+    SessionHandle handle = requireOwner(id, caller);
     registry.remove(handle.id());
     tracker.recordClientClose(handle.id());
     log.info("closed session id={}", id);
+  }
+
+  /**
+   * Looks up the session and verifies the caller owns it. Throws {@link
+   * io.browserservice.api.error.SessionNotFoundException} if the session is not registered (or has
+   * been closed) and {@link SessionForbiddenException} if the caller is not the owner.
+   */
+  public SessionHandle requireOwner(UUID id, CallerId caller) {
+    SessionHandle handle = registry.get(id);
+    if (!handle.owner().equals(caller)) {
+      throw new SessionForbiddenException(id);
+    }
+    return handle;
   }
 
   private SessionStateResponse toStateLocked(SessionHandle handle) {

--- a/api/src/main/java/io/browserservice/api/session/SessionHandle.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionHandle.java
@@ -6,6 +6,7 @@ import com.looksee.browser.enums.BrowserEnvironment;
 import com.looksee.browser.enums.BrowserType;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -18,6 +19,7 @@ public final class SessionHandle {
   private static final Logger log = LoggerFactory.getLogger(SessionHandle.class);
 
   private final UUID id;
+  private final CallerId owner;
   private final Browser browser; // null iff mobile session
   private final MobileDevice mobileDevice; // null iff desktop session
   private final BrowserType browserType;
@@ -32,6 +34,7 @@ public final class SessionHandle {
 
   private SessionHandle(
       UUID id,
+      CallerId owner,
       Browser browser,
       MobileDevice mobileDevice,
       BrowserType type,
@@ -39,6 +42,7 @@ public final class SessionHandle {
       Duration idleTtl,
       Duration absoluteTtl) {
     this.id = id;
+    this.owner = Objects.requireNonNull(owner, "owner");
     this.browser = browser;
     this.mobileDevice = mobileDevice;
     this.browserType = type;
@@ -54,24 +58,32 @@ public final class SessionHandle {
 
   public static SessionHandle desktop(
       Browser browser,
+      CallerId owner,
       BrowserType type,
       BrowserEnvironment env,
       Duration idleTtl,
       Duration absoluteTtl) {
-    return new SessionHandle(UUID.randomUUID(), browser, null, type, env, idleTtl, absoluteTtl);
+    return new SessionHandle(
+        UUID.randomUUID(), owner, browser, null, type, env, idleTtl, absoluteTtl);
   }
 
   public static SessionHandle mobile(
       MobileDevice device,
+      CallerId owner,
       BrowserType type,
       BrowserEnvironment env,
       Duration idleTtl,
       Duration absoluteTtl) {
-    return new SessionHandle(UUID.randomUUID(), null, device, type, env, idleTtl, absoluteTtl);
+    return new SessionHandle(
+        UUID.randomUUID(), owner, null, device, type, env, idleTtl, absoluteTtl);
   }
 
   public UUID id() {
     return id;
+  }
+
+  public CallerId owner() {
+    return owner;
   }
 
   public BrowserType browserType() {

--- a/api/src/main/java/io/browserservice/api/ws/CommandDispatcher.java
+++ b/api/src/main/java/io/browserservice/api/ws/CommandDispatcher.java
@@ -18,6 +18,7 @@ import io.browserservice.api.dto.ScreenshotRequest;
 import io.browserservice.api.dto.ScrollRequest;
 import io.browserservice.api.dto.SessionResponse;
 import io.browserservice.api.error.AlreadyBoundException;
+import io.browserservice.api.error.SessionForbiddenException;
 import io.browserservice.api.error.SessionNotBoundException;
 import io.browserservice.api.error.UnknownOpException;
 import io.browserservice.api.error.ValidationFailedException;
@@ -97,7 +98,7 @@ public class CommandDispatcher {
         (conn, params) -> {
           requireUnbound(conn);
           CreateSessionRequest req = parseAndValidate(params, CreateSessionRequest.class);
-          SessionResponse resp = sessionService.create(req);
+          SessionResponse resp = sessionService.create(req, conn.caller());
           ownership.claim(resp.sessionId(), conn.caller());
           conn.bind(resp.sessionId());
           watchers.onSessionAttached(resp.sessionId(), conn);
@@ -114,17 +115,27 @@ public class CommandDispatcher {
           // Resolve state first; only bind once we've confirmed the session is still alive.
           // Otherwise a SessionNotFoundException would leave the connection bound to a dead id
           // and fail every subsequent session.create / session.attach with already_bound.
-          Object state = sessionService.describe(sessionId);
+          // requireOwner inside describe enforces the SessionHandle.owner invariant — translate
+          // a forbidden mismatch into the WS-specific OwnershipMismatchException so the existing
+          // 4403 close path keeps working.
+          Object state;
+          try {
+            state = sessionService.describe(sessionId, conn.caller());
+          } catch (SessionForbiddenException e) {
+            throw new OwnershipMismatchException(sessionId);
+          }
           conn.bind(sessionId);
           watchers.onSessionAttached(sessionId, conn);
           return state;
         });
-    h.put("session.describe", (conn, params) -> sessionService.describe(requireBound(conn)));
+    h.put(
+        "session.describe",
+        (conn, params) -> sessionService.describe(requireBound(conn), conn.caller()));
     h.put(
         "session.close",
         (conn, params) -> {
           UUID id = requireBound(conn);
-          sessionService.close(id);
+          sessionService.close(id, conn.caller());
           watchers.onSessionDetached(id, conn);
           ownership.release(id);
           conn.unbind();
@@ -136,45 +147,55 @@ public class CommandDispatcher {
         "navigation.navigate",
         (conn, params) ->
             browserOps.navigate(
-                requireBound(conn), parseAndValidate(params, NavigateRequest.class)));
-    h.put("navigation.source", (conn, params) -> browserOps.getSource(requireBound(conn)));
-    h.put("navigation.status", (conn, params) -> browserOps.getStatus(requireBound(conn)));
+                requireBound(conn),
+                conn.caller(),
+                parseAndValidate(params, NavigateRequest.class)));
+    h.put(
+        "navigation.source",
+        (conn, params) -> browserOps.getSource(requireBound(conn), conn.caller()));
+    h.put(
+        "navigation.status",
+        (conn, params) -> browserOps.getStatus(requireBound(conn), conn.caller()));
 
     // Screenshots — WS-C: emit a (binary-header, binary-frame) pair instead of base64.
     h.put(
         "screenshot.page",
         (conn, params) -> {
           ScreenshotRequest req = parseAndValidate(params, ScreenshotRequest.class);
-          byte[] png = browserOps.pageScreenshot(requireBound(conn), req.strategy());
+          byte[] png = browserOps.pageScreenshot(requireBound(conn), conn.caller(), req.strategy());
           return new DispatchResult.Binary("image/png", png);
         });
     h.put(
         "screenshot.element",
         (conn, params) -> {
           ElementScreenshotRequest req = parseAndValidate(params, ElementScreenshotRequest.class);
-          byte[] png = elementOps.elementScreenshot(requireBound(conn), req);
+          byte[] png = elementOps.elementScreenshot(requireBound(conn), conn.caller(), req);
           return new DispatchResult.Binary("image/png", png);
         });
 
     // Capture (one-shot session under the hood; not bound to the WS connection)
     h.put(
         "capture.run",
-        (conn, params) -> captureService.capture(parseAndValidate(params, CaptureRequest.class)));
+        (conn, params) ->
+            captureService.capture(parseAndValidate(params, CaptureRequest.class), conn.caller()));
     h.put(
         "capture.fetchScreenshot",
         (conn, params) -> {
           UUID captureId = readUuid(params, "capture_id");
-          byte[] png = captureService.fetchScreenshot(captureId).pngBytes();
+          byte[] png = captureService.fetchScreenshot(captureId, conn.caller()).pngBytes();
           return new DispatchResult.Binary("image/png", png);
         });
 
     // Alerts
-    h.put("alert.state", (conn, params) -> alertService.getAlert(requireBound(conn)));
+    h.put(
+        "alert.state", (conn, params) -> alertService.getAlert(requireBound(conn), conn.caller()));
     h.put(
         "alert.respond",
         (conn, params) -> {
           alertService.respond(
-              requireBound(conn), parseAndValidate(params, AlertRespondRequest.class));
+              requireBound(conn),
+              conn.caller(),
+              parseAndValidate(params, AlertRespondRequest.class));
           return null;
         });
 
@@ -183,14 +204,14 @@ public class CommandDispatcher {
         "script.execute",
         (conn, params) ->
             browserOps.executeScript(
-                requireBound(conn), parseAndValidate(params, ExecuteRequest.class)));
+                requireBound(conn), conn.caller(), parseAndValidate(params, ExecuteRequest.class)));
 
     // Mouse
     h.put(
         "mouse.move",
         (conn, params) -> {
           browserOps.moveMouse(
-              requireBound(conn), parseAndValidate(params, MouseMoveRequest.class));
+              requireBound(conn), conn.caller(), parseAndValidate(params, MouseMoveRequest.class));
           return null;
         });
 
@@ -199,12 +220,16 @@ public class CommandDispatcher {
         "element.find",
         (conn, params) ->
             elementOps.find(
-                requireBound(conn), parseAndValidate(params, FindElementRequest.class)));
+                requireBound(conn),
+                conn.caller(),
+                parseAndValidate(params, FindElementRequest.class)));
     h.put(
         "element.action",
         (conn, params) -> {
           elementOps.action(
-              requireBound(conn), parseAndValidate(params, ElementActionRequest.class));
+              requireBound(conn),
+              conn.caller(),
+              parseAndValidate(params, ElementActionRequest.class));
           return null;
         });
 
@@ -212,7 +237,10 @@ public class CommandDispatcher {
     h.put(
         "touch.tap",
         (conn, params) -> {
-          elementOps.touch(requireBound(conn), parseAndValidate(params, ElementTouchRequest.class));
+          elementOps.touch(
+              requireBound(conn),
+              conn.caller(),
+              parseAndValidate(params, ElementTouchRequest.class));
           return null;
         });
 
@@ -220,17 +248,20 @@ public class CommandDispatcher {
     h.put(
         "scroll.to",
         (conn, params) ->
-            browserOps.scroll(requireBound(conn), parseAndValidate(params, ScrollRequest.class)));
+            browserOps.scroll(
+                requireBound(conn), conn.caller(), parseAndValidate(params, ScrollRequest.class)));
 
     // Viewport
-    h.put("viewport.state", (conn, params) -> browserOps.getViewport(requireBound(conn)));
+    h.put(
+        "viewport.state",
+        (conn, params) -> browserOps.getViewport(requireBound(conn), conn.caller()));
 
     // DOM
     h.put(
         "dom.remove",
         (conn, params) -> {
           browserOps.removeDom(
-              requireBound(conn), parseAndValidate(params, DomRemoveRequest.class));
+              requireBound(conn), conn.caller(), parseAndValidate(params, DomRemoveRequest.class));
           return null;
         });
 

--- a/api/src/test/java/io/browserservice/api/controller/ControllerHttpTest.java
+++ b/api/src/test/java/io/browserservice/api/controller/ControllerHttpTest.java
@@ -74,6 +74,7 @@ import io.browserservice.api.service.CaptureService;
 import io.browserservice.api.service.ElementOperationsService;
 import io.browserservice.api.service.ReadinessService;
 import io.browserservice.api.service.SessionService;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.CaptureScreenshotCache;
 import java.time.Instant;
 import java.util.List;
@@ -156,7 +157,7 @@ class ControllerHttpTest {
   @Test
   void createSessionReturns201() throws Exception {
     UUID id = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 id,
@@ -167,6 +168,7 @@ class ControllerHttpTest {
 
     mvc.perform(
             post("/v1/sessions")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -178,17 +180,22 @@ class ControllerHttpTest {
 
   @Test
   void createSessionValidationFailure() throws Exception {
-    mvc.perform(post("/v1/sessions").contentType(MediaType.APPLICATION_JSON).content("{}"))
+    mvc.perform(
+            post("/v1/sessions")
+                .header("X-Caller-Id", "alice")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error.code").value("validation_failed"));
   }
 
   @Test
   void createSessionCapExceeded() throws Exception {
-    when(sessionService.create(any())).thenThrow(new SessionCapExceededException(20));
+    when(sessionService.create(any(), any())).thenThrow(new SessionCapExceededException(20));
 
     mvc.perform(
             post("/v1/sessions")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -200,10 +207,11 @@ class ControllerHttpTest {
 
   @Test
   void createSessionUpstreamUnavailable() throws Exception {
-    when(sessionService.create(any())).thenThrow(new UpstreamUnavailableException("down"));
+    when(sessionService.create(any(), any())).thenThrow(new UpstreamUnavailableException("down"));
 
     mvc.perform(
             post("/v1/sessions")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -215,8 +223,8 @@ class ControllerHttpTest {
 
   @Test
   void listSessions() throws Exception {
-    when(sessionService.list()).thenReturn(new SessionListResponse(List.of()));
-    mvc.perform(get("/v1/sessions"))
+    when(sessionService.list(any())).thenReturn(new SessionListResponse(List.of()));
+    mvc.perform(get("/v1/sessions").header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.sessions").isArray());
   }
@@ -224,7 +232,7 @@ class ControllerHttpTest {
   @Test
   void getSession() throws Exception {
     UUID id = UUID.randomUUID();
-    when(sessionService.describe(id))
+    when(sessionService.describe(eq(id), any()))
         .thenReturn(
             new SessionStateResponse(
                 id,
@@ -236,7 +244,7 @@ class ControllerHttpTest {
                 new Viewport(100, 200),
                 new ScrollOffset(0, 0)));
 
-    mvc.perform(get("/v1/sessions/" + id))
+    mvc.perform(get("/v1/sessions/" + id).header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.current_url").value("https://x"));
   }
@@ -244,9 +252,9 @@ class ControllerHttpTest {
   @Test
   void getSessionNotFound() throws Exception {
     UUID id = UUID.randomUUID();
-    when(sessionService.describe(id)).thenThrow(new SessionNotFoundException(id));
+    when(sessionService.describe(eq(id), any())).thenThrow(new SessionNotFoundException(id));
 
-    mvc.perform(get("/v1/sessions/" + id))
+    mvc.perform(get("/v1/sessions/" + id).header("X-Caller-Id", "alice"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.code").value("session_not_found"));
   }
@@ -254,17 +262,69 @@ class ControllerHttpTest {
   @Test
   void deleteSessionReturns204() throws Exception {
     UUID id = UUID.randomUUID();
-    doNothing().when(sessionService).close(id);
+    doNothing().when(sessionService).close(eq(id), any(CallerId.class));
 
-    mvc.perform(delete("/v1/sessions/" + id)).andExpect(status().isNoContent());
-    verify(sessionService).close(id);
+    mvc.perform(delete("/v1/sessions/" + id).header("X-Caller-Id", "alice"))
+        .andExpect(status().isNoContent());
+    verify(sessionService).close(eq(id), any(CallerId.class));
   }
 
   @Test
   void deleteSessionWithInvalidUuidIs400() throws Exception {
-    mvc.perform(delete("/v1/sessions/not-a-uuid"))
+    mvc.perform(delete("/v1/sessions/not-a-uuid").header("X-Caller-Id", "alice"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error.code").value("validation_failed"));
+  }
+
+  // ---------- Caller-Id wiring (issues #47/#48) ----------
+
+  @Test
+  void missingCallerIdHeaderReturns400() throws Exception {
+    mvc.perform(get("/v1/sessions"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error.code").value("caller_unidentified"));
+  }
+
+  @Test
+  void wrongOwnerReturns403SessionForbidden() throws Exception {
+    UUID id = UUID.randomUUID();
+    when(sessionService.describe(eq(id), any()))
+        .thenThrow(new io.browserservice.api.error.SessionForbiddenException(id));
+
+    mvc.perform(get("/v1/sessions/" + id).header("X-Caller-Id", "bob"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.error.code").value("session_forbidden"))
+        .andExpect(jsonPath("$.error.details.session_id").value(id.toString()));
+  }
+
+  @Test
+  void listSessionsForwardsCallerToService() throws Exception {
+    UUID aliceSession = UUID.randomUUID();
+    when(sessionService.list(any()))
+        .thenAnswer(
+            inv -> {
+              CallerId caller = inv.getArgument(0);
+              if ("alice".equals(caller.value())) {
+                return new SessionListResponse(
+                    List.of(
+                        new SessionResponse(
+                            aliceSession,
+                            BrowserType.CHROME,
+                            BrowserEnvironment.TEST,
+                            Instant.now(),
+                            Instant.now().plusSeconds(60))));
+              }
+              return new SessionListResponse(List.of());
+            });
+
+    mvc.perform(get("/v1/sessions").header("X-Caller-Id", "alice"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessions[0].session_id").value(aliceSession.toString()));
+
+    mvc.perform(get("/v1/sessions").header("X-Caller-Id", "bob"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessions").isArray())
+        .andExpect(jsonPath("$.sessions[0]").doesNotExist());
   }
 
   // ---------- Navigation ----------
@@ -272,11 +332,12 @@ class ControllerHttpTest {
   @Test
   void navigateOk() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.navigate(eq(id), any()))
+    when(browserOps.navigate(eq(id), any(), any()))
         .thenReturn(new NavigateResponse("https://x", NavigateStatus.LOADED));
 
     mvc.perform(
             post("/v1/sessions/" + id + "/navigate")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.writeValueAsString(new NavigateRequest("https://x", null))))
         .andExpect(status().isOk())
@@ -286,8 +347,8 @@ class ControllerHttpTest {
   @Test
   void getSourceOk() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id)).thenReturn(new PageSourceResponse("u", "<html/>"));
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    when(browserOps.getSource(eq(id), any())).thenReturn(new PageSourceResponse("u", "<html/>"));
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.source").value("<html/>"));
   }
@@ -295,8 +356,8 @@ class ControllerHttpTest {
   @Test
   void getStatusOk() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getStatus(id)).thenReturn(new PageStatusResponse("u", false));
-    mvc.perform(get("/v1/sessions/" + id + "/status"))
+    when(browserOps.getStatus(eq(id), any())).thenReturn(new PageStatusResponse("u", false));
+    mvc.perform(get("/v1/sessions/" + id + "/status").header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.is503").value(false));
   }
@@ -307,10 +368,11 @@ class ControllerHttpTest {
   void screenshotBinaryResponse() throws Exception {
     UUID id = UUID.randomUUID();
     byte[] png = samplePng();
-    when(browserOps.pageScreenshot(eq(id), eq(ScreenshotStrategy.VIEWPORT))).thenReturn(png);
+    when(browserOps.pageScreenshot(eq(id), any(), eq(ScreenshotStrategy.VIEWPORT))).thenReturn(png);
 
     mvc.perform(
             post("/v1/sessions/" + id + "/screenshot")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.IMAGE_PNG)
                 .content(
@@ -323,11 +385,12 @@ class ControllerHttpTest {
   @Test
   void screenshotBase64Response() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.pageScreenshot(eq(id), eq(ScreenshotStrategy.VIEWPORT)))
+    when(browserOps.pageScreenshot(eq(id), any(), eq(ScreenshotStrategy.VIEWPORT)))
         .thenReturn(samplePng());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/screenshot")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(
@@ -342,11 +405,12 @@ class ControllerHttpTest {
   @Test
   void screenshotBase64HandlesUnparseableBytesGracefully() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.pageScreenshot(eq(id), eq(ScreenshotStrategy.VIEWPORT)))
+    when(browserOps.pageScreenshot(eq(id), any(), eq(ScreenshotStrategy.VIEWPORT)))
         .thenReturn(new byte[] {1, 2, 3});
 
     mvc.perform(
             post("/v1/sessions/" + id + "/screenshot")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(
@@ -359,10 +423,11 @@ class ControllerHttpTest {
   @Test
   void elementScreenshotBinary() throws Exception {
     UUID id = UUID.randomUUID();
-    when(elementOps.elementScreenshot(eq(id), any())).thenReturn(samplePng());
+    when(elementOps.elementScreenshot(eq(id), any(), any())).thenReturn(samplePng());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/element/screenshot")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.IMAGE_PNG)
                 .content(json.writeValueAsString(new ElementScreenshotRequest("el_1", null))))
@@ -375,11 +440,12 @@ class ControllerHttpTest {
   @Test
   void findElement() throws Exception {
     UUID id = UUID.randomUUID();
-    when(elementOps.find(eq(id), any()))
+    when(elementOps.find(eq(id), any(), any()))
         .thenReturn(new ElementStateResponse("el_1", true, true, Map.of(), new Rect(0, 0, 1, 1)));
 
     mvc.perform(
             post("/v1/sessions/" + id + "/element/find")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.writeValueAsString(new FindElementRequest("//h1"))))
         .andExpect(status().isOk())
@@ -389,10 +455,11 @@ class ControllerHttpTest {
   @Test
   void elementAction204() throws Exception {
     UUID id = UUID.randomUUID();
-    doNothing().when(elementOps).action(eq(id), any());
+    doNothing().when(elementOps).action(eq(id), any(), any());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/element/action")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(new ElementActionRequest("el_1", Action.CLICK, null))))
@@ -402,10 +469,11 @@ class ControllerHttpTest {
   @Test
   void elementActionOnMobileReturns409() throws Exception {
     UUID id = UUID.randomUUID();
-    doThrow(new DesktopSessionRequiredException()).when(elementOps).action(eq(id), any());
+    doThrow(new DesktopSessionRequiredException()).when(elementOps).action(eq(id), any(), any());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/element/action")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(new ElementActionRequest("el_1", Action.CLICK, null))))
@@ -416,10 +484,13 @@ class ControllerHttpTest {
   @Test
   void elementActionElementMissingReturns404() throws Exception {
     UUID id = UUID.randomUUID();
-    doThrow(new ElementHandleNotFoundException("el_1")).when(elementOps).action(eq(id), any());
+    doThrow(new ElementHandleNotFoundException("el_1"))
+        .when(elementOps)
+        .action(eq(id), any(), any());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/element/action")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(new ElementActionRequest("el_1", Action.CLICK, null))))
@@ -430,10 +501,11 @@ class ControllerHttpTest {
   @Test
   void elementTouch204() throws Exception {
     UUID id = UUID.randomUUID();
-    doNothing().when(elementOps).touch(eq(id), any());
+    doNothing().when(elementOps).touch(eq(id), any(), any());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/element/touch")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -444,10 +516,11 @@ class ControllerHttpTest {
   @Test
   void elementTouchOnDesktopReturns409() throws Exception {
     UUID id = UUID.randomUUID();
-    doThrow(new MobileSessionRequiredException()).when(elementOps).touch(eq(id), any());
+    doThrow(new MobileSessionRequiredException()).when(elementOps).touch(eq(id), any(), any());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/element/touch")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -461,10 +534,11 @@ class ControllerHttpTest {
   @Test
   void scrollOk() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.scroll(eq(id), any())).thenReturn(new ScrollOffset(0, 500));
+    when(browserOps.scroll(eq(id), any(), any())).thenReturn(new ScrollOffset(0, 500));
 
     mvc.perform(
             post("/v1/sessions/" + id + "/scroll")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(new ScrollRequest(ScrollMode.TO_BOTTOM, null, null))))
@@ -475,11 +549,12 @@ class ControllerHttpTest {
   @Test
   void scrollValidationFailure() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.scroll(eq(id), any()))
+    when(browserOps.scroll(eq(id), any(), any()))
         .thenThrow(new ValidationFailedException("element_handle is required for TO_ELEMENT"));
 
     mvc.perform(
             post("/v1/sessions/" + id + "/scroll")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(new ScrollRequest(ScrollMode.TO_ELEMENT, null, null))))
@@ -490,10 +565,10 @@ class ControllerHttpTest {
   @Test
   void getViewport() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getViewport(id))
+    when(browserOps.getViewport(eq(id), any()))
         .thenReturn(new ViewportStateResponse(new Viewport(1000, 800), new ScrollOffset(0, 0)));
 
-    mvc.perform(get("/v1/sessions/" + id + "/viewport"))
+    mvc.perform(get("/v1/sessions/" + id + "/viewport").header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.viewport.width").value(1000));
   }
@@ -503,10 +578,11 @@ class ControllerHttpTest {
   @Test
   void domRemove204() throws Exception {
     UUID id = UUID.randomUUID();
-    doNothing().when(browserOps).removeDom(eq(id), any());
+    doNothing().when(browserOps).removeDom(eq(id), any(), any());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/dom/remove")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -519,9 +595,9 @@ class ControllerHttpTest {
   @Test
   void getAlertOk() throws Exception {
     UUID id = UUID.randomUUID();
-    when(alertService.getAlert(id)).thenReturn(new AlertStateResponse(true, "hi"));
+    when(alertService.getAlert(eq(id), any())).thenReturn(new AlertStateResponse(true, "hi"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/alert"))
+    mvc.perform(get("/v1/sessions/" + id + "/alert").header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.present").value(true))
         .andExpect(jsonPath("$.text").value("hi"));
@@ -530,10 +606,11 @@ class ControllerHttpTest {
   @Test
   void respondAlert204() throws Exception {
     UUID id = UUID.randomUUID();
-    doNothing().when(alertService).respond(eq(id), any(AlertRespondRequest.class));
+    doNothing().when(alertService).respond(eq(id), any(), any(AlertRespondRequest.class));
 
     mvc.perform(
             post("/v1/sessions/" + id + "/alert/respond")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(new AlertRespondRequest(AlertChoice.ACCEPT, null))))
@@ -545,10 +622,11 @@ class ControllerHttpTest {
   @Test
   void mouseMove204() throws Exception {
     UUID id = UUID.randomUUID();
-    doNothing().when(browserOps).moveMouse(eq(id), any());
+    doNothing().when(browserOps).moveMouse(eq(id), any(), any());
 
     mvc.perform(
             post("/v1/sessions/" + id + "/mouse/move")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -561,10 +639,11 @@ class ControllerHttpTest {
   @Test
   void executeScript() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.executeScript(eq(id), any())).thenReturn(new ExecuteResponse(42));
+    when(browserOps.executeScript(eq(id), any(), any())).thenReturn(new ExecuteResponse(42));
 
     mvc.perform(
             post("/v1/sessions/" + id + "/execute")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.writeValueAsString(new ExecuteRequest("return 42;", null))))
         .andExpect(status().isOk())
@@ -576,7 +655,7 @@ class ControllerHttpTest {
   @Test
   void captureOk() throws Exception {
     UUID capId = UUID.randomUUID();
-    when(captureService.capture(any()))
+    when(captureService.capture(any(), any()))
         .thenReturn(
             new CaptureResponse(
                 capId,
@@ -587,6 +666,7 @@ class ControllerHttpTest {
 
     mvc.perform(
             post("/v1/capture")
+                .header("X-Caller-Id", "alice")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     json.writeValueAsString(
@@ -601,9 +681,9 @@ class ControllerHttpTest {
     UUID capId = UUID.randomUUID();
     CaptureScreenshotCache.CaptureEntry entry =
         new CaptureScreenshotCache.CaptureEntry(samplePng(), 2, 2, Instant.now().plusSeconds(60));
-    when(captureService.fetchScreenshot(capId)).thenReturn(entry);
+    when(captureService.fetchScreenshot(eq(capId), any())).thenReturn(entry);
 
-    mvc.perform(get("/v1/capture/" + capId + "/screenshot"))
+    mvc.perform(get("/v1/capture/" + capId + "/screenshot").header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.IMAGE_PNG));
   }
@@ -611,9 +691,10 @@ class ControllerHttpTest {
   @Test
   void captureScreenshotNotFound() throws Exception {
     UUID capId = UUID.randomUUID();
-    when(captureService.fetchScreenshot(capId)).thenThrow(new CaptureNotFoundException(capId));
+    when(captureService.fetchScreenshot(eq(capId), any()))
+        .thenThrow(new CaptureNotFoundException(capId));
 
-    mvc.perform(get("/v1/capture/" + capId + "/screenshot"))
+    mvc.perform(get("/v1/capture/" + capId + "/screenshot").header("X-Caller-Id", "alice"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.code").value("capture_not_found"));
   }
@@ -621,9 +702,10 @@ class ControllerHttpTest {
   @Test
   void captureScreenshotExpired() throws Exception {
     UUID capId = UUID.randomUUID();
-    when(captureService.fetchScreenshot(capId)).thenThrow(new CaptureExpiredException(capId));
+    when(captureService.fetchScreenshot(eq(capId), any()))
+        .thenThrow(new CaptureExpiredException(capId));
 
-    mvc.perform(get("/v1/capture/" + capId + "/screenshot"))
+    mvc.perform(get("/v1/capture/" + capId + "/screenshot").header("X-Caller-Id", "alice"))
         .andExpect(status().isGone())
         .andExpect(jsonPath("$.error.code").value("capture_expired"));
   }
@@ -633,9 +715,9 @@ class ControllerHttpTest {
   @Test
   void sessionBusyMapsTo409() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id)).thenThrow(new SessionBusyException(id));
+    when(browserOps.getSource(eq(id), any())).thenThrow(new SessionBusyException(id));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.error.code").value("session_busy"));
   }
@@ -643,9 +725,9 @@ class ControllerHttpTest {
   @Test
   void unknownWebDriverExceptionMapsTo502() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id)).thenThrow(new WebDriverException("driver exploded"));
+    when(browserOps.getSource(eq(id), any())).thenThrow(new WebDriverException("driver exploded"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isBadGateway())
         .andExpect(jsonPath("$.error.code").value("webdriver_error"));
   }
@@ -653,9 +735,9 @@ class ControllerHttpTest {
   @Test
   void unreachableBrowserMapsTo502() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id)).thenThrow(new UnreachableBrowserException("gone"));
+    when(browserOps.getSource(eq(id), any())).thenThrow(new UnreachableBrowserException("gone"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isBadGateway())
         .andExpect(jsonPath("$.error.code").value("upstream_unavailable"));
   }
@@ -663,10 +745,10 @@ class ControllerHttpTest {
   @Test
   void unknownSeleniumElementMapsTo404() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id))
+    when(browserOps.getSource(eq(id), any()))
         .thenThrow(new org.openqa.selenium.NoSuchElementException("gone"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.code").value("element_not_found"));
   }
@@ -674,9 +756,10 @@ class ControllerHttpTest {
   @Test
   void seleniumTimeoutMapsTo408() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id)).thenThrow(new org.openqa.selenium.TimeoutException("slow"));
+    when(browserOps.getSource(eq(id), any()))
+        .thenThrow(new org.openqa.selenium.TimeoutException("slow"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isRequestTimeout())
         .andExpect(jsonPath("$.error.code").value("upstream_timeout"));
   }
@@ -684,10 +767,10 @@ class ControllerHttpTest {
   @Test
   void unhandledAlertMapsTo409() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id))
+    when(browserOps.getSource(eq(id), any()))
         .thenThrow(new org.openqa.selenium.UnhandledAlertException("alert"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.error.code").value("unhandled_alert"));
   }
@@ -695,10 +778,10 @@ class ControllerHttpTest {
   @Test
   void staleElementMapsTo409() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id))
+    when(browserOps.getSource(eq(id), any()))
         .thenThrow(new org.openqa.selenium.StaleElementReferenceException("stale"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.error.code").value("stale_element"));
   }
@@ -706,9 +789,9 @@ class ControllerHttpTest {
   @Test
   void unexpectedErrorMapsTo500() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id)).thenThrow(new IllegalStateException("wat"));
+    when(browserOps.getSource(eq(id), any())).thenThrow(new IllegalStateException("wat"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isInternalServerError())
         .andExpect(jsonPath("$.error.code").value("internal_error"));
   }
@@ -716,14 +799,18 @@ class ControllerHttpTest {
   @Test
   void parameterTypeMismatchReturns400() throws Exception {
     // UUID path parameter receives a non-UUID → MethodArgumentTypeMismatchException
-    mvc.perform(get("/v1/sessions/not-a-uuid/source"))
+    mvc.perform(get("/v1/sessions/not-a-uuid/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error.code").value("validation_failed"));
   }
 
   @Test
   void unparseableJsonReturns400() throws Exception {
-    mvc.perform(post("/v1/sessions").contentType(MediaType.APPLICATION_JSON).content("{"))
+    mvc.perform(
+            post("/v1/sessions")
+                .header("X-Caller-Id", "alice")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.error.code").value("validation_failed"));
   }
@@ -731,9 +818,12 @@ class ControllerHttpTest {
   @Test
   void errorEnvelopeIncludesRequestId() throws Exception {
     UUID id = UUID.randomUUID();
-    when(sessionService.describe(id)).thenThrow(new SessionNotFoundException(id));
+    when(sessionService.describe(eq(id), any())).thenThrow(new SessionNotFoundException(id));
 
-    mvc.perform(get("/v1/sessions/" + id).header("X-Request-Id", "trace-1"))
+    mvc.perform(
+            get("/v1/sessions/" + id)
+                .header("X-Caller-Id", "alice")
+                .header("X-Request-Id", "trace-1"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.error.request_id").value("trace-1"))
         .andExpect(header().string("X-Request-Id", "trace-1"));
@@ -742,10 +832,10 @@ class ControllerHttpTest {
   @Test
   void errorMessageSanitizesMultiLineMessages() throws Exception {
     UUID id = UUID.randomUUID();
-    when(browserOps.getSource(id))
+    when(browserOps.getSource(eq(id), any()))
         .thenThrow(new WebDriverException("short message\nwith full stacktrace"));
 
-    mvc.perform(get("/v1/sessions/" + id + "/source"))
+    mvc.perform(get("/v1/sessions/" + id + "/source").header("X-Caller-Id", "alice"))
         .andExpect(status().isBadGateway())
         .andExpect(jsonPath("$.error.message").value(containsString("short message")));
     assertThat(true).isTrue();

--- a/api/src/test/java/io/browserservice/api/service/AlertServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/AlertServiceTest.java
@@ -13,6 +13,10 @@ import com.looksee.browser.enums.BrowserType;
 import io.browserservice.api.config.EngineProperties;
 import io.browserservice.api.dto.AlertRespondRequest;
 import io.browserservice.api.dto.AlertStateResponse;
+import io.browserservice.api.error.SessionForbiddenException;
+import io.browserservice.api.persistence.BrowserSessionTracker;
+import io.browserservice.api.session.CallerId;
+import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
 import io.browserservice.api.session.SessionRegistry;
@@ -20,11 +24,15 @@ import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.WebDriver;
 
 class AlertServiceTest {
+
+  private static final CallerId ALICE = CallerId.parse("alice");
+  private static final CallerId BOB = CallerId.parse("bob");
 
   private SessionRegistry registry;
   private SessionLocks locks;
@@ -35,7 +43,14 @@ class AlertServiceTest {
     EngineProperties props = props();
     registry = new SessionRegistry(props);
     locks = new SessionLocks(props);
-    service = new AlertService(registry, locks);
+    SessionService sessionService =
+        new SessionService(
+            registry,
+            locks,
+            Mockito.mock(DriverFactory.class),
+            Mockito.mock(BrowserSessionTracker.class),
+            props);
+    service = new AlertService(sessionService, locks);
   }
 
   @Test
@@ -48,7 +63,7 @@ class AlertServiceTest {
     when(alert.getText()).thenReturn("are you sure?");
     UUID id = register(browser);
 
-    AlertStateResponse resp = service.getAlert(id);
+    AlertStateResponse resp = service.getAlert(id, ALICE);
     assertThat(resp.present()).isTrue();
     assertThat(resp.text()).isEqualTo("are you sure?");
   }
@@ -61,7 +76,7 @@ class AlertServiceTest {
     when(driver.switchTo().alert()).thenThrow(new NoAlertPresentException("no"));
     UUID id = register(browser);
 
-    AlertStateResponse resp = service.getAlert(id);
+    AlertStateResponse resp = service.getAlert(id, ALICE);
     assertThat(resp.present()).isFalse();
     assertThat(resp.text()).isNull();
   }
@@ -74,7 +89,7 @@ class AlertServiceTest {
     when(driver.switchTo().alert()).thenThrow(new RuntimeException("other"));
     UUID id = register(browser);
 
-    AlertStateResponse resp = service.getAlert(id);
+    AlertStateResponse resp = service.getAlert(id, ALICE);
     assertThat(resp.present()).isFalse();
   }
 
@@ -88,7 +103,7 @@ class AlertServiceTest {
     when(alert.getText()).thenThrow(new RuntimeException("x"));
     UUID id = register(browser);
 
-    assertThat(service.getAlert(id).text()).isNull();
+    assertThat(service.getAlert(id, ALICE).text()).isNull();
   }
 
   @Test
@@ -100,7 +115,7 @@ class AlertServiceTest {
     when(driver.switchTo().alert()).thenReturn(alert);
     UUID id = register(browser);
 
-    service.respond(id, new AlertRespondRequest(AlertChoice.ACCEPT, null));
+    service.respond(id, ALICE, new AlertRespondRequest(AlertChoice.ACCEPT, null));
     verify(alert).accept();
     verify(alert, never()).dismiss();
   }
@@ -114,7 +129,7 @@ class AlertServiceTest {
     when(driver.switchTo().alert()).thenReturn(alert);
     UUID id = register(browser);
 
-    service.respond(id, new AlertRespondRequest(AlertChoice.DISMISS, null));
+    service.respond(id, ALICE, new AlertRespondRequest(AlertChoice.DISMISS, null));
     verify(alert).dismiss();
   }
 
@@ -127,7 +142,7 @@ class AlertServiceTest {
     when(driver.switchTo().alert()).thenReturn(alert);
     UUID id = register(browser);
 
-    service.respond(id, new AlertRespondRequest(AlertChoice.ACCEPT, "hello"));
+    service.respond(id, ALICE, new AlertRespondRequest(AlertChoice.ACCEPT, "hello"));
     verify(alert).sendKeys("hello");
     verify(alert).accept();
   }
@@ -144,8 +159,25 @@ class AlertServiceTest {
         .sendKeys("x");
     UUID id = register(browser);
 
-    service.respond(id, new AlertRespondRequest(AlertChoice.ACCEPT, "x"));
+    service.respond(id, ALICE, new AlertRespondRequest(AlertChoice.ACCEPT, "x"));
     verify(alert).accept();
+  }
+
+  @Test
+  void getAlertWithWrongOwnerThrowsSessionForbidden() {
+    Browser browser = mock(Browser.class);
+    UUID id = register(browser);
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.getAlert(id, BOB))
+        .isInstanceOf(SessionForbiddenException.class);
+  }
+
+  @Test
+  void respondWithWrongOwnerThrowsSessionForbidden() {
+    Browser browser = mock(Browser.class);
+    UUID id = register(browser);
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> service.respond(id, BOB, new AlertRespondRequest(AlertChoice.ACCEPT, null)))
+        .isInstanceOf(SessionForbiddenException.class);
   }
 
   @Test
@@ -156,7 +188,7 @@ class AlertServiceTest {
     when(driver.switchTo().alert()).thenThrow(new NoAlertPresentException("none"));
     UUID id = register(browser);
 
-    service.respond(id, new AlertRespondRequest(AlertChoice.ACCEPT, null));
+    service.respond(id, ALICE, new AlertRespondRequest(AlertChoice.ACCEPT, null));
     // No throw; no verification target.
     assertThat(true).isTrue();
   }
@@ -165,6 +197,7 @@ class AlertServiceTest {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            ALICE,
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/service/BrowserOperationsServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/BrowserOperationsServiceTest.java
@@ -29,7 +29,11 @@ import io.browserservice.api.dto.ScrollRequest;
 import io.browserservice.api.dto.ViewportStateResponse;
 import io.browserservice.api.error.DesktopSessionRequiredException;
 import io.browserservice.api.error.ElementHandleNotFoundException;
+import io.browserservice.api.error.SessionForbiddenException;
 import io.browserservice.api.error.ValidationFailedException;
+import io.browserservice.api.persistence.BrowserSessionTracker;
+import io.browserservice.api.session.CallerId;
+import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
 import io.browserservice.api.session.SessionRegistry;
@@ -48,6 +52,9 @@ import org.openqa.selenium.WebElement;
 
 class BrowserOperationsServiceTest {
 
+  private static final CallerId ALICE = CallerId.parse("alice");
+  private static final CallerId BOB = CallerId.parse("bob");
+
   private SessionRegistry registry;
   private SessionLocks locks;
   private BrowserOperationsService service;
@@ -57,7 +64,14 @@ class BrowserOperationsServiceTest {
     EngineProperties props = props();
     registry = new SessionRegistry(props);
     locks = new SessionLocks(props);
-    service = new BrowserOperationsService(registry, locks);
+    SessionService sessionService =
+        new SessionService(
+            registry,
+            locks,
+            org.mockito.Mockito.mock(DriverFactory.class),
+            org.mockito.Mockito.mock(BrowserSessionTracker.class),
+            props);
+    service = new BrowserOperationsService(sessionService, locks);
   }
 
   @Test
@@ -68,7 +82,8 @@ class BrowserOperationsServiceTest {
     when(driver.getCurrentUrl()).thenReturn("https://example.com");
     UUID id = register(browser);
 
-    NavigateResponse resp = service.navigate(id, new NavigateRequest("https://example.com", null));
+    NavigateResponse resp =
+        service.navigate(id, ALICE, new NavigateRequest("https://example.com", null));
 
     assertThat(resp.status()).isEqualTo(NavigateStatus.LOADED);
     assertThat(resp.currentUrl()).isEqualTo("https://example.com");
@@ -85,7 +100,7 @@ class BrowserOperationsServiceTest {
     UUID id = registerMobile(device);
 
     NavigateResponse resp =
-        service.navigate(id, new NavigateRequest("https://m.example.com", null));
+        service.navigate(id, ALICE, new NavigateRequest("https://m.example.com", null));
     assertThat(resp.status()).isEqualTo(NavigateStatus.LOADED);
   }
 
@@ -98,7 +113,8 @@ class BrowserOperationsServiceTest {
     org.mockito.Mockito.doThrow(new TimeoutException("slow")).when(browser).waitForPageToLoad();
     UUID id = register(browser);
 
-    NavigateResponse resp = service.navigate(id, new NavigateRequest("https://example.com", null));
+    NavigateResponse resp =
+        service.navigate(id, ALICE, new NavigateRequest("https://example.com", null));
     assertThat(resp.status()).isEqualTo(NavigateStatus.TIMEOUT);
   }
 
@@ -111,7 +127,7 @@ class BrowserOperationsServiceTest {
     org.mockito.Mockito.doThrow(new RuntimeException("broken")).when(browser).navigateTo("x");
     UUID id = register(browser);
 
-    NavigateResponse resp = service.navigate(id, new NavigateRequest("x", null));
+    NavigateResponse resp = service.navigate(id, ALICE, new NavigateRequest("x", null));
     assertThat(resp.status()).isEqualTo(NavigateStatus.ERROR);
   }
 
@@ -124,7 +140,7 @@ class BrowserOperationsServiceTest {
     when(browser.getSource()).thenReturn("<html/>");
     UUID id = register(browser);
 
-    PageSourceResponse resp = service.getSource(id);
+    PageSourceResponse resp = service.getSource(id, ALICE);
     assertThat(resp.source()).isEqualTo("<html/>");
     assertThat(resp.currentUrl()).isEqualTo("u");
   }
@@ -138,7 +154,7 @@ class BrowserOperationsServiceTest {
     when(device.getSource()).thenReturn("<html/>");
     UUID id = registerMobile(device);
 
-    PageSourceResponse resp = service.getSource(id);
+    PageSourceResponse resp = service.getSource(id, ALICE);
     assertThat(resp.source()).isEqualTo("<html/>");
   }
 
@@ -152,7 +168,7 @@ class BrowserOperationsServiceTest {
         .thenReturn("<html><title>503 Service Temporarily Unavailable</title></html>");
     UUID id = register(browser);
 
-    PageStatusResponse resp = service.getStatus(id);
+    PageStatusResponse resp = service.getStatus(id, ALICE);
     assertThat(resp.is503()).isTrue();
   }
 
@@ -165,7 +181,7 @@ class BrowserOperationsServiceTest {
     when(browser.getSource()).thenReturn("<html><body>ok</body></html>");
     UUID id = register(browser);
 
-    PageStatusResponse resp = service.getStatus(id);
+    PageStatusResponse resp = service.getStatus(id, ALICE);
     assertThat(resp.is503()).isFalse();
   }
 
@@ -178,7 +194,7 @@ class BrowserOperationsServiceTest {
     when(browser.getSource()).thenThrow(new RuntimeException("nope"));
     UUID id = register(browser);
 
-    assertThat(service.getStatus(id).is503()).isFalse();
+    assertThat(service.getStatus(id, ALICE).is503()).isFalse();
   }
 
   @Test
@@ -190,7 +206,7 @@ class BrowserOperationsServiceTest {
     when(browser.getViewportScrollOffset()).thenReturn(new Point(5, 10));
     UUID id = register(browser);
 
-    ViewportStateResponse resp = service.getViewport(id);
+    ViewportStateResponse resp = service.getViewport(id, ALICE);
     assertThat(resp.viewport().width()).isEqualTo(800);
     assertThat(resp.viewport().height()).isEqualTo(600);
     assertThat(resp.scrollOffset().x()).isEqualTo(5);
@@ -204,7 +220,8 @@ class BrowserOperationsServiceTest {
     when(browser.getViewportScrollOffset()).thenReturn(new Point(0, 0));
     UUID id = register(browser);
 
-    ScrollOffset offset = service.scroll(id, new ScrollRequest(ScrollMode.TO_TOP, null, null));
+    ScrollOffset offset =
+        service.scroll(id, ALICE, new ScrollRequest(ScrollMode.TO_TOP, null, null));
     assertThat(offset.x()).isZero();
     verify(browser).scrollToTopOfPage();
   }
@@ -217,7 +234,7 @@ class BrowserOperationsServiceTest {
     when(browser.getViewportScrollOffset()).thenReturn(new Point(0, 100));
     UUID id = register(browser);
 
-    service.scroll(id, new ScrollRequest(ScrollMode.TO_BOTTOM, null, null));
+    service.scroll(id, ALICE, new ScrollRequest(ScrollMode.TO_BOTTOM, null, null));
     verify(browser).scrollToBottomOfPage();
   }
 
@@ -229,7 +246,7 @@ class BrowserOperationsServiceTest {
     UUID id = register(browser);
 
     assertThatThrownBy(
-            () -> service.scroll(id, new ScrollRequest(ScrollMode.TO_ELEMENT, null, null)))
+            () -> service.scroll(id, ALICE, new ScrollRequest(ScrollMode.TO_ELEMENT, null, null)))
         .isInstanceOf(ValidationFailedException.class);
   }
 
@@ -242,6 +259,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            ALICE,
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -251,7 +269,7 @@ class BrowserOperationsServiceTest {
     WebElement element = mock(WebElement.class);
     String elHandle = handle.elements().put(element);
 
-    service.scroll(handle.id(), new ScrollRequest(ScrollMode.TO_ELEMENT, elHandle, null));
+    service.scroll(handle.id(), ALICE, new ScrollRequest(ScrollMode.TO_ELEMENT, elHandle, null));
     verify(browser).scrollToElement(element);
   }
 
@@ -263,7 +281,9 @@ class BrowserOperationsServiceTest {
     UUID id = register(browser);
 
     assertThatThrownBy(
-            () -> service.scroll(id, new ScrollRequest(ScrollMode.TO_ELEMENT, "el_missing", null)))
+            () ->
+                service.scroll(
+                    id, ALICE, new ScrollRequest(ScrollMode.TO_ELEMENT, "el_missing", null)))
         .isInstanceOf(ElementHandleNotFoundException.class);
   }
 
@@ -276,6 +296,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            ALICE,
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -285,7 +306,8 @@ class BrowserOperationsServiceTest {
     WebElement element = mock(WebElement.class);
     String elHandle = handle.elements().put(element);
 
-    service.scroll(handle.id(), new ScrollRequest(ScrollMode.TO_ELEMENT_CENTERED, elHandle, null));
+    service.scroll(
+        handle.id(), ALICE, new ScrollRequest(ScrollMode.TO_ELEMENT_CENTERED, elHandle, null));
     verify(browser).scrollToElementCentered(element);
   }
 
@@ -298,6 +320,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            ALICE,
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -307,7 +330,8 @@ class BrowserOperationsServiceTest {
     WebElement element = mock(WebElement.class);
     String elHandle = handle.elements().put(element);
 
-    service.scroll(handle.id(), new ScrollRequest(ScrollMode.TO_ELEMENT_CENTERED, elHandle, null));
+    service.scroll(
+        handle.id(), ALICE, new ScrollRequest(ScrollMode.TO_ELEMENT_CENTERED, elHandle, null));
     verify(device).scrollToElement(element);
   }
 
@@ -319,7 +343,9 @@ class BrowserOperationsServiceTest {
     UUID id = register(browser);
 
     assertThatThrownBy(
-            () -> service.scroll(id, new ScrollRequest(ScrollMode.TO_ELEMENT_CENTERED, "", null)))
+            () ->
+                service.scroll(
+                    id, ALICE, new ScrollRequest(ScrollMode.TO_ELEMENT_CENTERED, "", null)))
         .isInstanceOf(ValidationFailedException.class);
   }
 
@@ -331,7 +357,7 @@ class BrowserOperationsServiceTest {
     UUID id = register(browser);
 
     assertThatThrownBy(
-            () -> service.scroll(id, new ScrollRequest(ScrollMode.DOWN_PERCENT, null, null)))
+            () -> service.scroll(id, ALICE, new ScrollRequest(ScrollMode.DOWN_PERCENT, null, null)))
         .isInstanceOf(ValidationFailedException.class);
   }
 
@@ -343,7 +369,7 @@ class BrowserOperationsServiceTest {
     when(browser.getViewportScrollOffset()).thenReturn(new Point(0, 100));
     UUID id = register(browser);
 
-    service.scroll(id, new ScrollRequest(ScrollMode.DOWN_PERCENT, null, 0.5));
+    service.scroll(id, ALICE, new ScrollRequest(ScrollMode.DOWN_PERCENT, null, 0.5));
     verify(browser).scrollDownPercent(0.5);
   }
 
@@ -355,7 +381,7 @@ class BrowserOperationsServiceTest {
     when(browser.getViewportScrollOffset()).thenReturn(new Point(0, 100));
     UUID id = register(browser);
 
-    service.scroll(id, new ScrollRequest(ScrollMode.DOWN_FULL, null, null));
+    service.scroll(id, ALICE, new ScrollRequest(ScrollMode.DOWN_FULL, null, null));
     verify(browser).scrollDownFull();
   }
 
@@ -368,6 +394,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            ALICE,
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -375,7 +402,7 @@ class BrowserOperationsServiceTest {
     registry.acquirePermit();
     registry.register(handle);
 
-    service.scroll(handle.id(), new ScrollRequest(ScrollMode.TO_TOP, null, null));
+    service.scroll(handle.id(), ALICE, new ScrollRequest(ScrollMode.TO_TOP, null, null));
     verify(device).scrollToTopOfPage();
   }
 
@@ -388,6 +415,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            ALICE,
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -395,7 +423,7 @@ class BrowserOperationsServiceTest {
     registry.acquirePermit();
     registry.register(handle);
 
-    service.scroll(handle.id(), new ScrollRequest(ScrollMode.TO_BOTTOM, null, null));
+    service.scroll(handle.id(), ALICE, new ScrollRequest(ScrollMode.TO_BOTTOM, null, null));
     verify(device).scrollToBottomOfPage();
   }
 
@@ -408,6 +436,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            ALICE,
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -415,7 +444,7 @@ class BrowserOperationsServiceTest {
     registry.acquirePermit();
     registry.register(handle);
 
-    service.scroll(handle.id(), new ScrollRequest(ScrollMode.DOWN_PERCENT, null, 0.25));
+    service.scroll(handle.id(), ALICE, new ScrollRequest(ScrollMode.DOWN_PERCENT, null, 0.25));
     verify(device).scrollDownPercent(0.25);
   }
 
@@ -428,6 +457,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            ALICE,
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -435,7 +465,7 @@ class BrowserOperationsServiceTest {
     registry.acquirePermit();
     registry.register(handle);
 
-    service.scroll(handle.id(), new ScrollRequest(ScrollMode.DOWN_FULL, null, null));
+    service.scroll(handle.id(), ALICE, new ScrollRequest(ScrollMode.DOWN_FULL, null, null));
     verify(device).scrollDownFull();
   }
 
@@ -448,7 +478,7 @@ class BrowserOperationsServiceTest {
     when(browser.getViewportScreenshot()).thenReturn(img);
     UUID id = register(browser);
 
-    byte[] bytes = service.pageScreenshot(id, ScreenshotStrategy.VIEWPORT);
+    byte[] bytes = service.pageScreenshot(id, ALICE, ScreenshotStrategy.VIEWPORT);
     assertThat(bytes).isNotEmpty();
   }
 
@@ -461,7 +491,7 @@ class BrowserOperationsServiceTest {
     when(browser.getFullPageScreenshot()).thenReturn(img);
     UUID id = register(browser);
 
-    byte[] bytes = service.pageScreenshot(id, ScreenshotStrategy.FULL_PAGE_SHUTTERBUG);
+    byte[] bytes = service.pageScreenshot(id, ALICE, ScreenshotStrategy.FULL_PAGE_SHUTTERBUG);
     assertThat(bytes).isNotEmpty();
   }
 
@@ -474,7 +504,7 @@ class BrowserOperationsServiceTest {
     when(browser.getFullPageScreenshotAshot()).thenReturn(img);
     UUID id = register(browser);
 
-    byte[] bytes = service.pageScreenshot(id, ScreenshotStrategy.FULL_PAGE_ASHOT);
+    byte[] bytes = service.pageScreenshot(id, ALICE, ScreenshotStrategy.FULL_PAGE_ASHOT);
     assertThat(bytes).isNotEmpty();
   }
 
@@ -487,7 +517,8 @@ class BrowserOperationsServiceTest {
     when(browser.getFullPageScreenshotShutterbug()).thenReturn(img);
     UUID id = register(browser);
 
-    byte[] bytes = service.pageScreenshot(id, ScreenshotStrategy.FULL_PAGE_SHUTTERBUG_PAUSED);
+    byte[] bytes =
+        service.pageScreenshot(id, ALICE, ScreenshotStrategy.FULL_PAGE_SHUTTERBUG_PAUSED);
     assertThat(bytes).isNotEmpty();
   }
 
@@ -500,7 +531,7 @@ class BrowserOperationsServiceTest {
     when(device.getViewportScreenshot()).thenReturn(img);
     UUID id = registerMobile(device);
 
-    byte[] bytes = service.pageScreenshot(id, ScreenshotStrategy.VIEWPORT);
+    byte[] bytes = service.pageScreenshot(id, ALICE, ScreenshotStrategy.VIEWPORT);
     assertThat(bytes).isNotEmpty();
   }
 
@@ -513,7 +544,7 @@ class BrowserOperationsServiceTest {
     when(device.getFullPageScreenshot()).thenReturn(img);
     UUID id = registerMobile(device);
 
-    byte[] bytes = service.pageScreenshot(id, ScreenshotStrategy.FULL_PAGE_ASHOT);
+    byte[] bytes = service.pageScreenshot(id, ALICE, ScreenshotStrategy.FULL_PAGE_ASHOT);
     assertThat(bytes).isNotEmpty();
     verify(device).getFullPageScreenshot();
   }
@@ -526,7 +557,7 @@ class BrowserOperationsServiceTest {
     when(browser.getViewportScreenshot()).thenThrow(new java.io.IOException("disk"));
     UUID id = register(browser);
 
-    assertThatThrownBy(() -> service.pageScreenshot(id, ScreenshotStrategy.VIEWPORT))
+    assertThatThrownBy(() -> service.pageScreenshot(id, ALICE, ScreenshotStrategy.VIEWPORT))
         .isInstanceOf(io.browserservice.api.error.UpstreamUnavailableException.class);
   }
 
@@ -538,7 +569,7 @@ class BrowserOperationsServiceTest {
     UUID id = registerMobile(device);
 
     assertThatThrownBy(
-            () -> service.removeDom(id, new DomRemoveRequest(DomRemovePreset.GDPR, null)))
+            () -> service.removeDom(id, ALICE, new DomRemoveRequest(DomRemovePreset.GDPR, null)))
         .isInstanceOf(DesktopSessionRequiredException.class);
   }
 
@@ -550,7 +581,8 @@ class BrowserOperationsServiceTest {
     UUID id = register(browser);
 
     assertThatThrownBy(
-            () -> service.removeDom(id, new DomRemoveRequest(DomRemovePreset.BY_CLASS, null)))
+            () ->
+                service.removeDom(id, ALICE, new DomRemoveRequest(DomRemovePreset.BY_CLASS, null)))
         .isInstanceOf(ValidationFailedException.class);
   }
 
@@ -561,16 +593,16 @@ class BrowserOperationsServiceTest {
     when(browser.getDriver()).thenReturn(driver);
     UUID id = register(browser);
 
-    service.removeDom(id, new DomRemoveRequest(DomRemovePreset.DRIFT_CHAT, null));
+    service.removeDom(id, ALICE, new DomRemoveRequest(DomRemovePreset.DRIFT_CHAT, null));
     verify(browser).removeDriftChat();
 
-    service.removeDom(id, new DomRemoveRequest(DomRemovePreset.GDPR_MODAL, null));
+    service.removeDom(id, ALICE, new DomRemoveRequest(DomRemovePreset.GDPR_MODAL, null));
     verify(browser).removeGDPRmodals();
 
-    service.removeDom(id, new DomRemoveRequest(DomRemovePreset.GDPR, null));
+    service.removeDom(id, ALICE, new DomRemoveRequest(DomRemovePreset.GDPR, null));
     verify(browser).removeGDPR();
 
-    service.removeDom(id, new DomRemoveRequest(DomRemovePreset.BY_CLASS, "chat-widget"));
+    service.removeDom(id, ALICE, new DomRemoveRequest(DomRemovePreset.BY_CLASS, "chat-widget"));
     verify(browser).removeElement("chat-widget");
   }
 
@@ -583,7 +615,8 @@ class BrowserOperationsServiceTest {
 
     assertThatThrownBy(
             () ->
-                service.moveMouse(id, new MouseMoveRequest(MouseMoveMode.OUT_OF_FRAME, null, null)))
+                service.moveMouse(
+                    id, ALICE, new MouseMoveRequest(MouseMoveMode.OUT_OF_FRAME, null, null)))
         .isInstanceOf(DesktopSessionRequiredException.class);
   }
 
@@ -594,7 +627,7 @@ class BrowserOperationsServiceTest {
     when(browser.getDriver()).thenReturn(driver);
     UUID id = register(browser);
 
-    service.moveMouse(id, new MouseMoveRequest(MouseMoveMode.OUT_OF_FRAME, null, null));
+    service.moveMouse(id, ALICE, new MouseMoveRequest(MouseMoveMode.OUT_OF_FRAME, null, null));
     verify(browser).moveMouseOutOfFrame();
   }
 
@@ -608,7 +641,7 @@ class BrowserOperationsServiceTest {
     assertThatThrownBy(
             () ->
                 service.moveMouse(
-                    id, new MouseMoveRequest(MouseMoveMode.TO_NON_INTERACTIVE, null, 5)))
+                    id, ALICE, new MouseMoveRequest(MouseMoveMode.TO_NON_INTERACTIVE, null, 5)))
         .isInstanceOf(ValidationFailedException.class);
   }
 
@@ -619,7 +652,7 @@ class BrowserOperationsServiceTest {
     when(browser.getDriver()).thenReturn(driver);
     UUID id = register(browser);
 
-    service.moveMouse(id, new MouseMoveRequest(MouseMoveMode.TO_NON_INTERACTIVE, 10, 20));
+    service.moveMouse(id, ALICE, new MouseMoveRequest(MouseMoveMode.TO_NON_INTERACTIVE, 10, 20));
     verify(browser).moveMouseToNonInteractive(new Point(10, 20));
   }
 
@@ -634,7 +667,7 @@ class BrowserOperationsServiceTest {
     when(((JavascriptExecutor) driver).executeScript("return 42;")).thenReturn(42L);
     UUID id = register(browser);
 
-    ExecuteResponse resp = service.executeScript(id, new ExecuteRequest("return 42;", null));
+    ExecuteResponse resp = service.executeScript(id, ALICE, new ExecuteRequest("return 42;", null));
     assertThat(resp.result()).isEqualTo(42L);
   }
 
@@ -648,15 +681,24 @@ class BrowserOperationsServiceTest {
     when(browser.getDriver()).thenReturn(driver);
     UUID id = register(browser);
 
-    service.executeScript(id, new ExecuteRequest("return arguments[0];", List.of("hello")));
+    service.executeScript(id, ALICE, new ExecuteRequest("return arguments[0];", List.of("hello")));
     verify((JavascriptExecutor) driver)
         .executeScript("return arguments[0];", new Object[] {"hello"});
+  }
+
+  @Test
+  void getSourceWithWrongOwnerThrowsSessionForbidden() {
+    Browser browser = mock(Browser.class);
+    UUID id = register(browser);
+    assertThatThrownBy(() -> service.getSource(id, BOB))
+        .isInstanceOf(SessionForbiddenException.class);
   }
 
   private UUID register(Browser browser) {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            ALICE,
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -670,6 +712,7 @@ class BrowserOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            ALICE,
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/service/CaptureServiceMoreTest.java
+++ b/api/src/test/java/io/browserservice/api/service/CaptureServiceMoreTest.java
@@ -13,6 +13,7 @@ import io.browserservice.api.config.EngineProperties;
 import io.browserservice.api.dto.CaptureRequest;
 import io.browserservice.api.dto.PngEncoding;
 import io.browserservice.api.error.UpstreamUnavailableException;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.CaptureScreenshotCache;
 import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionLocks;
@@ -23,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 
 class CaptureServiceMoreTest {
+
+  private static final CallerId ALICE = CallerId.parse("alice");
 
   private SessionRegistry registry;
   private SessionLocks locks;
@@ -51,7 +54,8 @@ class CaptureServiceMoreTest {
     assertThatThrownBy(
             () ->
                 service.capture(
-                    new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null)))
+                    new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null),
+                    ALICE))
         .isInstanceOf(RuntimeException.class);
 
     // Permit released after the capture session was cleaned up.
@@ -72,7 +76,8 @@ class CaptureServiceMoreTest {
             () ->
                 service.capture(
                     new CaptureRequest(
-                        "u", BrowserType.CHROME, null, null, PngEncoding.BASE64, null, null)))
+                        "u", BrowserType.CHROME, null, null, PngEncoding.BASE64, null, null),
+                    ALICE))
         .isInstanceOf(UpstreamUnavailableException.class);
     assertThat(registry.size()).isZero();
   }
@@ -89,7 +94,8 @@ class CaptureServiceMoreTest {
 
     var resp =
         service.capture(
-            new CaptureRequest("u", BrowserType.CHROME, null, null, PngEncoding.BASE64, "", null));
+            new CaptureRequest("u", BrowserType.CHROME, null, null, PngEncoding.BASE64, "", null),
+            ALICE);
     assertThat(resp.element()).isNull();
   }
 

--- a/api/src/test/java/io/browserservice/api/service/CaptureServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/CaptureServiceTest.java
@@ -16,6 +16,7 @@ import io.browserservice.api.dto.CaptureResponse;
 import io.browserservice.api.dto.PngEncoding;
 import io.browserservice.api.dto.ScreenshotStrategy;
 import io.browserservice.api.error.UpstreamUnavailableException;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.CaptureScreenshotCache;
 import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionLocks;
@@ -30,6 +31,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 class CaptureServiceTest {
+
+  private static final CallerId ALICE = CallerId.parse("alice");
 
   private SessionRegistry registry;
   private SessionLocks locks;
@@ -66,7 +69,8 @@ class CaptureServiceTest {
                 ScreenshotStrategy.VIEWPORT,
                 PngEncoding.BASE64,
                 null,
-                null));
+                null),
+            ALICE);
 
     assertThat(resp.screenshot().imageBase64()).isNotBlank();
     assertThat(resp.screenshot().href()).isNull();
@@ -85,7 +89,8 @@ class CaptureServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     CaptureResponse resp =
-        service.capture(new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null));
+        service.capture(
+            new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null), ALICE);
 
     assertThat(resp.screenshot().href()).startsWith("/v1/capture/");
     assertThat(resp.screenshot().imageBase64()).isNull();
@@ -104,8 +109,8 @@ class CaptureServiceTest {
 
     CaptureResponse resp =
         service.capture(
-            new CaptureRequest(
-                "u", BrowserType.CHROME, null, null, PngEncoding.BASE64, null, true));
+            new CaptureRequest("u", BrowserType.CHROME, null, null, PngEncoding.BASE64, null, true),
+            ALICE);
 
     assertThat(resp.source()).isEqualTo("<html>hi</html>");
   }
@@ -128,7 +133,8 @@ class CaptureServiceTest {
     CaptureResponse resp =
         service.capture(
             new CaptureRequest(
-                "u", BrowserType.CHROME, null, null, PngEncoding.BASE64, "//h1", null));
+                "u", BrowserType.CHROME, null, null, PngEncoding.BASE64, "//h1", null),
+            ALICE);
 
     assertThat(resp.element()).isNotNull();
     assertThat(resp.element().found()).isTrue();
@@ -149,7 +155,8 @@ class CaptureServiceTest {
     CaptureResponse resp =
         service.capture(
             new CaptureRequest(
-                "u", BrowserType.CHROME, null, null, PngEncoding.BASE64, "//missing", null));
+                "u", BrowserType.CHROME, null, null, PngEncoding.BASE64, "//missing", null),
+            ALICE);
 
     assertThat(resp.element().found()).isFalse();
   }
@@ -167,7 +174,8 @@ class CaptureServiceTest {
     CaptureResponse resp =
         service.capture(
             new CaptureRequest(
-                "u", BrowserType.ANDROID, null, null, PngEncoding.BASE64, null, null));
+                "u", BrowserType.ANDROID, null, null, PngEncoding.BASE64, null, null),
+            ALICE);
     assertThat(resp).isNotNull();
     verify(device).navigateTo("u");
   }
@@ -180,7 +188,8 @@ class CaptureServiceTest {
     assertThatThrownBy(
             () ->
                 service.capture(
-                    new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null)))
+                    new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null),
+                    ALICE))
         .isInstanceOf(UpstreamUnavailableException.class);
     assertThat(registry.availablePermits()).isEqualTo(5);
   }
@@ -196,7 +205,8 @@ class CaptureServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     CaptureResponse resp =
-        service.capture(new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null));
+        service.capture(
+            new CaptureRequest("u", BrowserType.CHROME, null, null, null, null, null), ALICE);
     java.util.UUID id =
         java.util.UUID.fromString(
             resp.screenshot()
@@ -205,7 +215,7 @@ class CaptureServiceTest {
                     "/v1/capture/".length(),
                     resp.screenshot().href().length() - "/screenshot".length()));
 
-    CaptureScreenshotCache.CaptureEntry entry = service.fetchScreenshot(id);
+    CaptureScreenshotCache.CaptureEntry entry = service.fetchScreenshot(id, ALICE);
     assertThat(entry.pngBytes()).isNotEmpty();
   }
 

--- a/api/src/test/java/io/browserservice/api/service/ElementOperationsServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/ElementOperationsServiceTest.java
@@ -19,6 +19,10 @@ import io.browserservice.api.dto.ElementTouchRequest;
 import io.browserservice.api.dto.FindElementRequest;
 import io.browserservice.api.error.DesktopSessionRequiredException;
 import io.browserservice.api.error.MobileSessionRequiredException;
+import io.browserservice.api.error.SessionForbiddenException;
+import io.browserservice.api.persistence.BrowserSessionTracker;
+import io.browserservice.api.session.CallerId;
+import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
 import io.browserservice.api.session.SessionRegistry;
@@ -34,6 +38,9 @@ import org.openqa.selenium.WebElement;
 
 class ElementOperationsServiceTest {
 
+  private static final CallerId ALICE = CallerId.parse("alice");
+  private static final CallerId BOB = CallerId.parse("bob");
+
   private SessionRegistry registry;
   private SessionLocks locks;
   private ElementOperationsService service;
@@ -43,7 +50,14 @@ class ElementOperationsServiceTest {
     EngineProperties props = props();
     registry = new SessionRegistry(props);
     locks = new SessionLocks(props);
-    service = new ElementOperationsService(registry, locks);
+    SessionService sessionService =
+        new SessionService(
+            registry,
+            locks,
+            org.mockito.Mockito.mock(DriverFactory.class),
+            org.mockito.Mockito.mock(BrowserSessionTracker.class),
+            props);
+    service = new ElementOperationsService(sessionService, locks);
   }
 
   @Test
@@ -58,7 +72,7 @@ class ElementOperationsServiceTest {
     when(browser.extractAttributes(element)).thenReturn(Map.of("id", "x"));
     SessionHandle handle = registerDesktop(browser);
 
-    ElementStateResponse resp = service.find(handle.id(), new FindElementRequest("//h1"));
+    ElementStateResponse resp = service.find(handle.id(), ALICE, new FindElementRequest("//h1"));
 
     assertThat(resp.found()).isTrue();
     assertThat(resp.displayed()).isTrue();
@@ -80,7 +94,7 @@ class ElementOperationsServiceTest {
     when(element.getRect()).thenThrow(new RuntimeException("nope"));
     SessionHandle handle = registerMobile(device);
 
-    ElementStateResponse resp = service.find(handle.id(), new FindElementRequest("//btn"));
+    ElementStateResponse resp = service.find(handle.id(), ALICE, new FindElementRequest("//btn"));
 
     assertThat(resp.found()).isTrue();
     assertThat(resp.displayed()).isFalse();
@@ -95,7 +109,8 @@ class ElementOperationsServiceTest {
     when(browser.findElement("//missing")).thenThrow(new NoSuchElementException("no"));
     SessionHandle handle = registerDesktop(browser);
 
-    ElementStateResponse resp = service.find(handle.id(), new FindElementRequest("//missing"));
+    ElementStateResponse resp =
+        service.find(handle.id(), ALICE, new FindElementRequest("//missing"));
     assertThat(resp.found()).isFalse();
     assertThat(resp.elementHandle()).isNull();
     assertThat(resp.attributes()).isEmpty();
@@ -112,7 +127,7 @@ class ElementOperationsServiceTest {
     when(browser.extractAttributes(element)).thenReturn(Map.of());
     SessionHandle handle = registerDesktop(browser);
 
-    ElementStateResponse resp = service.find(handle.id(), new FindElementRequest("//x"));
+    ElementStateResponse resp = service.find(handle.id(), ALICE, new FindElementRequest("//x"));
     assertThat(resp.displayed()).isFalse();
   }
 
@@ -124,7 +139,9 @@ class ElementOperationsServiceTest {
     SessionHandle handle = registerMobile(device);
 
     assertThatThrownBy(
-            () -> service.action(handle.id(), new ElementActionRequest("el_1", Action.CLICK, null)))
+            () ->
+                service.action(
+                    handle.id(), ALICE, new ElementActionRequest("el_1", Action.CLICK, null)))
         .isInstanceOf(DesktopSessionRequiredException.class);
   }
 
@@ -140,7 +157,7 @@ class ElementOperationsServiceTest {
     assertThatThrownBy(
             () ->
                 service.action(
-                    handle.id(), new ElementActionRequest("el_missing", Action.CLICK, null)))
+                    handle.id(), ALICE, new ElementActionRequest("el_missing", Action.CLICK, null)))
         .isInstanceOf(io.browserservice.api.error.ElementHandleNotFoundException.class);
   }
 
@@ -153,7 +170,8 @@ class ElementOperationsServiceTest {
 
     assertThatThrownBy(
             () ->
-                service.touch(handle.id(), new ElementTouchRequest("el_1", MobileAction.TAP, null)))
+                service.touch(
+                    handle.id(), ALICE, new ElementTouchRequest("el_1", MobileAction.TAP, null)))
         .isInstanceOf(MobileSessionRequiredException.class);
   }
 
@@ -168,7 +186,8 @@ class ElementOperationsServiceTest {
     SessionHandle handle = registerDesktop(browser);
     String h = handle.elements().put(element);
 
-    byte[] bytes = service.elementScreenshot(handle.id(), new ElementScreenshotRequest(h, null));
+    byte[] bytes =
+        service.elementScreenshot(handle.id(), ALICE, new ElementScreenshotRequest(h, null));
     assertThat(bytes).isNotEmpty();
   }
 
@@ -183,7 +202,8 @@ class ElementOperationsServiceTest {
     SessionHandle handle = registerMobile(device);
     String h = handle.elements().put(element);
 
-    byte[] bytes = service.elementScreenshot(handle.id(), new ElementScreenshotRequest(h, null));
+    byte[] bytes =
+        service.elementScreenshot(handle.id(), ALICE, new ElementScreenshotRequest(h, null));
     assertThat(bytes).isNotEmpty();
   }
 
@@ -198,7 +218,9 @@ class ElementOperationsServiceTest {
     String h = handle.elements().put(element);
 
     assertThatThrownBy(
-            () -> service.elementScreenshot(handle.id(), new ElementScreenshotRequest(h, null)))
+            () ->
+                service.elementScreenshot(
+                    handle.id(), ALICE, new ElementScreenshotRequest(h, null)))
         .isInstanceOf(io.browserservice.api.error.UpstreamUnavailableException.class);
   }
 
@@ -213,14 +235,25 @@ class ElementOperationsServiceTest {
     String h = handle.elements().put(element);
 
     assertThatThrownBy(
-            () -> service.elementScreenshot(handle.id(), new ElementScreenshotRequest(h, null)))
+            () ->
+                service.elementScreenshot(
+                    handle.id(), ALICE, new ElementScreenshotRequest(h, null)))
         .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void findWithWrongOwnerThrowsSessionForbidden() {
+    Browser browser = mock(Browser.class);
+    SessionHandle handle = registerDesktop(browser);
+    assertThatThrownBy(() -> service.find(handle.id(), BOB, new FindElementRequest("//x")))
+        .isInstanceOf(SessionForbiddenException.class);
   }
 
   private SessionHandle registerDesktop(Browser browser) {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            ALICE,
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -234,6 +267,7 @@ class ElementOperationsServiceTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            ALICE,
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
@@ -16,9 +16,11 @@ import io.browserservice.api.dto.SessionListResponse;
 import io.browserservice.api.dto.SessionResponse;
 import io.browserservice.api.dto.SessionStateResponse;
 import io.browserservice.api.error.SessionCapExceededException;
+import io.browserservice.api.error.SessionForbiddenException;
 import io.browserservice.api.error.SessionNotFoundException;
 import io.browserservice.api.error.UpstreamUnavailableException;
 import io.browserservice.api.persistence.BrowserSessionTracker;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.DriverFactory;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
@@ -31,6 +33,9 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 
 class SessionServiceTest {
+
+  private static final CallerId ALICE = CallerId.parse("alice");
+  private static final CallerId BOB = CallerId.parse("bob");
 
   private SessionRegistry registry;
   private SessionLocks locks;
@@ -54,7 +59,8 @@ class SessionServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     SessionResponse response =
-        service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
 
     assertThat(response.browserType()).isEqualTo(BrowserType.CHROME);
     assertThat(response.environment()).isEqualTo(BrowserEnvironment.TEST);
@@ -68,7 +74,8 @@ class SessionServiceTest {
     when(drivers.createMobile(BrowserType.ANDROID, BrowserEnvironment.TEST)).thenReturn(device);
 
     SessionResponse response =
-        service.create(new CreateSessionRequest(BrowserType.ANDROID, BrowserEnvironment.TEST, 120));
+        service.create(
+            new CreateSessionRequest(BrowserType.ANDROID, BrowserEnvironment.TEST, 120), ALICE);
 
     assertThat(response.browserType()).isEqualTo(BrowserType.ANDROID);
     assertThat(response.sessionId()).isNotNull();
@@ -79,7 +86,8 @@ class SessionServiceTest {
     Browser browser = mockBrowserWithDriver();
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
-    service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, 42));
+    service.create(
+        new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, 42), ALICE);
 
     // One session was stored
     assertThat(registry.snapshot())
@@ -96,7 +104,8 @@ class SessionServiceTest {
     assertThatThrownBy(
             () ->
                 service.create(
-                    new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null)))
+                    new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null),
+                    ALICE))
         .isInstanceOf(UpstreamUnavailableException.class);
 
     assertThat(registry.availablePermits()).isEqualTo(2);
@@ -113,7 +122,8 @@ class SessionServiceTest {
     assertThatThrownBy(
             () ->
                 service.create(
-                    new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null)))
+                    new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null),
+                    ALICE))
         .isInstanceOf(RuntimeException.class);
 
     verify(browser).close();
@@ -126,24 +136,43 @@ class SessionServiceTest {
     Browser browser = mockBrowserWithDriver();
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
-    service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
-    service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
+    service.create(
+        new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    service.create(
+        new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
 
     assertThatThrownBy(
             () ->
                 service.create(
-                    new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null)))
+                    new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null),
+                    ALICE))
         .isInstanceOf(SessionCapExceededException.class);
   }
 
   @Test
-  void listReturnsAllOpenSessions() {
+  void listReturnsAllOpenSessionsForCaller() {
     Browser browser = mockBrowserWithDriver();
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
-    service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
-    SessionListResponse list = service.list();
+    service.create(
+        new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    SessionListResponse list = service.list(ALICE);
     assertThat(list.sessions()).hasSize(1);
+  }
+
+  @Test
+  void listFiltersByCaller() {
+    Browser browser = mockBrowserWithDriver();
+    when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+
+    service.create(
+        new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    service.create(
+        new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), BOB);
+
+    assertThat(service.list(ALICE).sessions()).hasSize(1);
+    assertThat(service.list(BOB).sessions()).hasSize(1);
+    assertThat(service.list(CallerId.parse("eve")).sessions()).isEmpty();
   }
 
   @Test
@@ -153,8 +182,9 @@ class SessionServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     SessionResponse created =
-        service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
-    SessionStateResponse state = service.describe(created.sessionId());
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    SessionStateResponse state = service.describe(created.sessionId(), ALICE);
 
     assertThat(state.sessionId()).isEqualTo(created.sessionId());
     assertThat(state.viewport()).isNotNull();
@@ -164,8 +194,20 @@ class SessionServiceTest {
 
   @Test
   void describeUnknownIdThrowsSessionNotFound() {
-    assertThatThrownBy(() -> service.describe(UUID.randomUUID()))
+    assertThatThrownBy(() -> service.describe(UUID.randomUUID(), ALICE))
         .isInstanceOf(SessionNotFoundException.class);
+  }
+
+  @Test
+  void describeRequiresOwner() {
+    Browser browser = mockBrowserWithDriver();
+    when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+    SessionResponse created =
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+
+    assertThatThrownBy(() -> service.describe(created.sessionId(), BOB))
+        .isInstanceOf(SessionForbiddenException.class);
   }
 
   @Test
@@ -177,8 +219,9 @@ class SessionServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     SessionResponse created =
-        service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
-    SessionStateResponse state = service.describe(created.sessionId());
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    SessionStateResponse state = service.describe(created.sessionId(), ALICE);
 
     assertThat(state.currentUrl()).isNull();
     assertThat(state.viewport()).isNull();
@@ -191,11 +234,25 @@ class SessionServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     SessionResponse created =
-        service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
-    service.close(created.sessionId());
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    service.close(created.sessionId(), ALICE);
 
     verify(browser).close();
     assertThat(registry.size()).isZero();
+  }
+
+  @Test
+  void closeRequiresOwner() {
+    Browser browser = mockBrowserWithDriver();
+    when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+    SessionResponse created =
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+
+    assertThatThrownBy(() -> service.close(created.sessionId(), BOB))
+        .isInstanceOf(SessionForbiddenException.class);
+    assertThat(registry.size()).isEqualTo(1);
   }
 
   @Test
@@ -204,12 +261,14 @@ class SessionServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     SessionResponse created =
-        service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
 
     org.mockito.ArgumentCaptor<SessionHandle> captor =
         org.mockito.ArgumentCaptor.forClass(SessionHandle.class);
     verify(tracker).recordCreate(captor.capture());
     assertThat(captor.getValue().id()).isEqualTo(created.sessionId());
+    assertThat(captor.getValue().owner()).isEqualTo(ALICE);
   }
 
   @Test
@@ -218,15 +277,48 @@ class SessionServiceTest {
     when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
 
     SessionResponse created =
-        service.create(new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null));
-    service.close(created.sessionId());
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    service.close(created.sessionId(), ALICE);
 
     verify(tracker).recordClientClose(created.sessionId());
   }
 
   @Test
   void closeUnknownIdThrowsSessionNotFound() {
-    assertThatThrownBy(() -> service.close(UUID.randomUUID()))
+    assertThatThrownBy(() -> service.close(UUID.randomUUID(), ALICE))
+        .isInstanceOf(SessionNotFoundException.class);
+  }
+
+  @Test
+  void requireOwnerHappyPathReturnsHandle() {
+    Browser browser = mockBrowserWithDriver();
+    when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+
+    SessionResponse created =
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    SessionHandle handle = service.requireOwner(created.sessionId(), ALICE);
+
+    assertThat(handle.id()).isEqualTo(created.sessionId());
+    assertThat(handle.owner()).isEqualTo(ALICE);
+  }
+
+  @Test
+  void requireOwnerMismatchThrowsSessionForbidden() {
+    Browser browser = mockBrowserWithDriver();
+    when(drivers.createDesktop(BrowserType.CHROME, BrowserEnvironment.TEST)).thenReturn(browser);
+
+    SessionResponse created =
+        service.create(
+            new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), ALICE);
+    assertThatThrownBy(() -> service.requireOwner(created.sessionId(), BOB))
+        .isInstanceOf(SessionForbiddenException.class);
+  }
+
+  @Test
+  void requireOwnerOnUnknownSessionThrowsSessionNotFound() {
+    assertThatThrownBy(() -> service.requireOwner(UUID.randomUUID(), ALICE))
         .isInstanceOf(SessionNotFoundException.class);
   }
 

--- a/api/src/test/java/io/browserservice/api/session/SessionHandleTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionHandleTest.java
@@ -26,6 +26,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -55,6 +56,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            CallerId.parse("alice"),
             BrowserType.ANDROID,
             BrowserEnvironment.DISCOVERY,
             Duration.ofSeconds(15),
@@ -63,6 +65,7 @@ class SessionHandleTest {
     assertThat(handle.isMobile()).isTrue();
     assertThat(handle.asMobileDevice()).isSameAs(device);
     assertThat(handle.driver()).isSameAs(driver);
+    assertThat(handle.owner().value()).isEqualTo("alice");
     assertThatThrownBy(handle::asBrowser).isInstanceOf(IllegalStateException.class);
   }
 
@@ -72,6 +75,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -84,6 +88,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -99,6 +104,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -124,6 +130,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(10),
@@ -139,6 +146,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofMillis(1),
@@ -152,6 +160,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -171,6 +180,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -185,6 +195,7 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            CallerId.parse("alice"),
             BrowserType.ANDROID,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
@@ -200,10 +211,41 @@ class SessionHandleTest {
     SessionHandle handle =
         SessionHandle.mobile(
             device,
+            CallerId.parse("alice"),
             BrowserType.IOS,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),
             Duration.ofSeconds(60));
     assertThat(handle.closeOnce()).isTrue();
+  }
+
+  @Test
+  void desktopFactoryRejectsNullOwner() {
+    Browser browser = mock(Browser.class);
+    assertThatThrownBy(
+            () ->
+                SessionHandle.desktop(
+                    browser,
+                    null,
+                    BrowserType.CHROME,
+                    BrowserEnvironment.TEST,
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(60)))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  void mobileFactoryRejectsNullOwner() {
+    MobileDevice device = mock(MobileDevice.class);
+    assertThatThrownBy(
+            () ->
+                SessionHandle.mobile(
+                    device,
+                    null,
+                    BrowserType.ANDROID,
+                    BrowserEnvironment.TEST,
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(60)))
+        .isInstanceOf(NullPointerException.class);
   }
 }

--- a/api/src/test/java/io/browserservice/api/session/SessionLocksTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionLocksTest.java
@@ -25,6 +25,7 @@ class SessionLocksTest {
     handle =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(10),

--- a/api/src/test/java/io/browserservice/api/session/SessionLocksTryDoWithLockTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionLocksTryDoWithLockTest.java
@@ -45,6 +45,7 @@ class SessionLocksTryDoWithLockTest {
     handle =
         SessionHandle.desktop(
             Mockito.mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
@@ -26,6 +26,7 @@ class SessionReaperTest {
     SessionHandle expired =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofMillis(1),
@@ -33,6 +34,7 @@ class SessionReaperTest {
     SessionHandle active =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(60),
@@ -62,6 +64,7 @@ class SessionReaperTest {
     SessionHandle absoluteExpired =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(60),
@@ -83,6 +86,7 @@ class SessionReaperTest {
     SessionHandle handle =
         SessionHandle.desktop(
             mock(Browser.class),
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(60),

--- a/api/src/test/java/io/browserservice/api/session/SessionRegistryTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionRegistryTest.java
@@ -114,6 +114,7 @@ class SessionRegistryTest {
   private static SessionHandle newHandle() {
     return SessionHandle.desktop(
         mock(Browser.class),
+        CallerId.parse("alice"),
         BrowserType.CHROME,
         BrowserEnvironment.TEST,
         Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/ws/SessionWebSocketHandlerTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/SessionWebSocketHandlerTest.java
@@ -2,6 +2,7 @@ package io.browserservice.api.ws;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
@@ -105,7 +106,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void sessionCreateBindsAndEchoesId() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -134,7 +135,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void sessionAttachAsWrongOwnerClosesWith4403() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -199,7 +200,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void serviceExceptionsMapToErrorFrameWithSameCodeAsRest() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -207,7 +208,7 @@ class SessionWebSocketHandlerTest {
                 BrowserEnvironment.TEST,
                 Instant.now(),
                 Instant.now().plusSeconds(60)));
-    when(browserOps.navigate(any(), any())).thenThrow(new WebDriverException("boom"));
+    when(browserOps.navigate(any(), any(), any())).thenThrow(new WebDriverException("boom"));
 
     TestHandler handler = new TestHandler();
     WebSocketSession ws = client.execute(handler, headers("alice"), uri()).get(5, TimeUnit.SECONDS);
@@ -234,7 +235,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void validationFailureReturnsValidationFailedCode() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -268,7 +269,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void successfulNavigateRoundTrip() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -276,7 +277,7 @@ class SessionWebSocketHandlerTest {
                 BrowserEnvironment.TEST,
                 Instant.now(),
                 Instant.now().plusSeconds(60)));
-    when(browserOps.navigate(any(), any()))
+    when(browserOps.navigate(any(), any(), any()))
         .thenReturn(new NavigateResponse("https://example.com", NavigateStatus.LOADED));
 
     TestHandler handler = new TestHandler();
@@ -304,7 +305,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void describeAfterBindUsesBoundSessionId() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -312,7 +313,7 @@ class SessionWebSocketHandlerTest {
                 BrowserEnvironment.TEST,
                 Instant.now(),
                 Instant.now().plusSeconds(60)));
-    when(sessionService.describe(sid))
+    when(sessionService.describe(eq(sid), any()))
         .thenReturn(
             new SessionStateResponse(
                 sid,
@@ -346,7 +347,7 @@ class SessionWebSocketHandlerTest {
   void sessionCloseUnbindsConnectionAndAllowsCreateAgain() throws Exception {
     UUID first = UUID.randomUUID();
     UUID second = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 first,
@@ -361,7 +362,7 @@ class SessionWebSocketHandlerTest {
                 BrowserEnvironment.TEST,
                 Instant.now(),
                 Instant.now().plusSeconds(60)));
-    doNothing().when(sessionService).close(any());
+    doNothing().when(sessionService).close(any(), any());
 
     TestHandler handler = new TestHandler();
     WebSocketSession ws = client.execute(handler, headers("alice"), uri()).get(5, TimeUnit.SECONDS);
@@ -392,7 +393,7 @@ class SessionWebSocketHandlerTest {
   void attachDoesNotBindIfDescribeFails() throws Exception {
     UUID sid = UUID.randomUUID();
     // Alice creates the session so ownership is recorded.
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -410,8 +411,8 @@ class SessionWebSocketHandlerTest {
     a1.close();
 
     // Now alice opens a fresh connection and the session has been reaped.
-    when(sessionService.describe(sid)).thenThrow(new SessionNotFoundException(sid));
-    when(sessionService.create(any()))
+    when(sessionService.describe(eq(sid), any())).thenThrow(new SessionNotFoundException(sid));
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 UUID.randomUUID(),
@@ -453,7 +454,7 @@ class SessionWebSocketHandlerTest {
     // outbound ConcurrentWebSocketSessionDecorator. Round-tripping a normal create
     // confirms the decorator's buffer accommodates real frames.
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -491,7 +492,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void doubleBindFails() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -524,7 +525,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void screenshotPageEmitsHeaderThenBinaryFrame() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -533,7 +534,7 @@ class SessionWebSocketHandlerTest {
                 Instant.now(),
                 Instant.now().plusSeconds(60)));
     byte[] png = makePng(8, 6);
-    when(browserOps.pageScreenshot(any(), any())).thenReturn(png);
+    when(browserOps.pageScreenshot(any(), any(), any())).thenReturn(png);
 
     TestHandler handler = new TestHandler();
     WebSocketSession ws = client.execute(handler, headers("alice"), uri()).get(5, TimeUnit.SECONDS);
@@ -570,7 +571,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void captureFetchScreenshotEmitsBinaryFrame() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -580,7 +581,7 @@ class SessionWebSocketHandlerTest {
                 Instant.now().plusSeconds(60)));
     UUID captureId = UUID.randomUUID();
     byte[] png = makePng(4, 4);
-    when(captureService.fetchScreenshot(captureId))
+    when(captureService.fetchScreenshot(eq(captureId), any()))
         .thenReturn(
             new CaptureScreenshotCache.CaptureEntry(png, 4, 4, Instant.now().plusSeconds(60)));
 
@@ -614,7 +615,7 @@ class SessionWebSocketHandlerTest {
   @Test
   void oversizeScreenshotProducesErrorAndNoBinaryFrame() throws Exception {
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -625,7 +626,7 @@ class SessionWebSocketHandlerTest {
     // Default test prop is 16 MiB; produce a 17 MiB byte array (any bytes — server only
     // checks length before computing sha or sending the binary frame).
     byte[] huge = new byte[17 * 1024 * 1024];
-    when(browserOps.pageScreenshot(any(), any())).thenReturn(huge);
+    when(browserOps.pageScreenshot(any(), any(), any())).thenReturn(huge);
 
     TestHandler handler = new TestHandler();
     WebSocketSession ws = client.execute(handler, headers("alice"), uri()).get(5, TimeUnit.SECONDS);
@@ -658,7 +659,7 @@ class SessionWebSocketHandlerTest {
     // header MUST be immediately followed by the binary frame; no text frame may
     // land between them.
     UUID sid = UUID.randomUUID();
-    when(sessionService.create(any()))
+    when(sessionService.create(any(), any()))
         .thenReturn(
             new SessionResponse(
                 sid,
@@ -668,7 +669,7 @@ class SessionWebSocketHandlerTest {
                 Instant.now().plusSeconds(60)));
     byte[] png = makePng(8, 6);
     // Make pageScreenshot slow so the test actively races writers.
-    when(browserOps.pageScreenshot(any(), any()))
+    when(browserOps.pageScreenshot(any(), any(), any()))
         .thenAnswer(
             inv -> {
               Thread.sleep(50);
@@ -685,7 +686,7 @@ class SessionWebSocketHandlerTest {
       handler.takeJson(json);
 
       // Concurrent flooder firing a small describe (text response) over and over.
-      when(sessionService.describe(sid))
+      when(sessionService.describe(eq(sid), any()))
           .thenReturn(
               new SessionStateResponse(
                   sid,

--- a/api/src/test/java/io/browserservice/api/ws/push/AlertWatcherTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/AlertWatcherTest.java
@@ -13,6 +13,7 @@ import com.looksee.browser.Browser;
 import com.looksee.browser.enums.BrowserEnvironment;
 import com.looksee.browser.enums.BrowserType;
 import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
 import io.browserservice.api.ws.dto.EventFrame;
@@ -64,6 +65,7 @@ class AlertWatcherTest {
     handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/ws/push/BrowserLogDrainTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/BrowserLogDrainTest.java
@@ -12,6 +12,7 @@ import com.looksee.browser.Browser;
 import com.looksee.browser.enums.BrowserEnvironment;
 import com.looksee.browser.enums.BrowserType;
 import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
 import io.browserservice.api.ws.dto.EventFrame;
@@ -70,6 +71,7 @@ class BrowserLogDrainTest {
     handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/ws/push/NavigationWatcherTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/NavigationWatcherTest.java
@@ -13,6 +13,7 @@ import com.looksee.browser.Browser;
 import com.looksee.browser.enums.BrowserEnvironment;
 import com.looksee.browser.enums.BrowserType;
 import io.browserservice.api.config.EngineProperties;
+import io.browserservice.api.session.CallerId;
 import io.browserservice.api.session.SessionHandle;
 import io.browserservice.api.session.SessionLocks;
 import io.browserservice.api.ws.dto.EventFrame;
@@ -67,6 +68,7 @@ class NavigationWatcherTest {
     handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),

--- a/api/src/test/java/io/browserservice/api/ws/push/WatcherCoordinatorTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/push/WatcherCoordinatorTest.java
@@ -64,6 +64,7 @@ class WatcherCoordinatorTest {
     handle =
         SessionHandle.desktop(
             browser,
+            CallerId.parse("alice"),
             BrowserType.CHROME,
             BrowserEnvironment.TEST,
             Duration.ofSeconds(30),


### PR DESCRIPTION
## Summary

Lands issues #47 (domain) and #48 (controllers) together. After this merges, the wire contract flips: every request under `/v1/` requires `X-Caller-Id` and `SessionHandle.owner` is the single source of truth for ownership.

- `SessionHandle` carries a non-null `CallerId owner`; both factories require it.
- `SessionService.requireOwner(id, caller)` is the single enforcement point. Mismatch → `SessionForbiddenException` → **403 `session_forbidden`**. Missing/invalid header (resolved by the resolver from #46) → **400 `caller_unidentified`**.
- `SessionService.list(caller)` filters by caller.
- All 12 `/v1/*` controllers declare `CallerId`; `OpsController` (`/healthz`, `/readyz`) stays anonymous.
- WS dispatcher passes `conn.caller()` into every per-session call. `WsSessionOwnership` stays for one more PR (deletion is #49); `SessionForbiddenException` from `describe`-on-attach is wrapped as `OwnershipMismatchException` so the existing `4403` close path is unchanged.
- `OpenApiConfig` tells springdoc to ignore `CallerId` as a parameter type (otherwise it would surface each method's `caller` as a query parameter); the `X-Caller-Id` header continues to be added by the customizer from #46.

Why combined: the original 5-PR plan kept #47 behaviour-neutral via transitional `@Deprecated` wrappers / a `systemRest()` sentinel, then flipped in #48. Combining deletes one PR's worth of dead code that would have existed only to be removed in #48.

Out of scope (deferred): `WsSessionOwnership` deletion (#49), `ownerId` in DTOs / reaper log (#50), cross-caller capture cache isolation, admin "list all sessions" (#45).

## Test plan
- [x] `./mvnw -pl api -am test` — 264 tests, 0 failures
- [x] `./mvnw -pl api -am verify -DskipITs` — Spotless, Checkstyle, SpotBugs, PMD, JaCoCo all green
- [x] `SpecExportTest` — OpenAPI snapshot unchanged (no `caller` query parameter leakage)
- [x] New tests in `ControllerHttpTest`: `missingCallerIdHeaderReturns400`, `wrongOwnerReturns403SessionForbidden`, `listSessionsForwardsCallerToService`
- [x] New tests in `SessionServiceTest`: `requireOwnerHappyPath`, `requireOwnerMismatchThrowsSessionForbidden`, `requireOwnerOnUnknownSessionThrowsSessionNotFound`, `listFiltersByCaller`, `describeRequiresOwner`, `closeRequiresOwner`
- [x] New tests in `SessionHandleTest`: `desktopFactoryRejectsNullOwner`, `mobileFactoryRejectsNullOwner`
- [x] Wrong-owner mismatch tests in `AlertServiceTest`, `BrowserOperationsServiceTest`, `ElementOperationsServiceTest`
- [ ] Manual smoke: `curl -i -X POST localhost:8080/v1/sessions -H 'Content-Type: application/json' -d '{"browserType":"CHROME","environment":"TEST"}'` → 400 `caller_unidentified`
- [ ] Manual smoke: `curl -i localhost:8080/v1/sessions/$ID -H 'X-Caller-Id: bob'` for an alice-owned session → 403 `session_forbidden`
- [ ] Manual smoke: `curl -i localhost:8080/healthz` → 200 (no header required)
- [ ] WS regression: alice creates a session, bob attempts `session.attach` → `4403` close (unchanged)

Closes #47.
Closes #48.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Hm9HNfzz8dSy4a5La55C5)_