### PR TITLE
feat(terraform): GCP module to stand up browser-service + Selenium fleet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Project conventions for Claude
+
+## Diagrams
+
+Always use [Mermaid](https://mermaid.js.org/) for diagrams in markdown
+(architecture, sequence, flow, ERD, etc.). Never use ASCII / box-drawing
+diagrams — Mermaid renders natively on GitHub and is easier to maintain.
+
+This applies to READMEs, PR descriptions, design docs, and any new markdown
+in this repo.

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,21 @@
+# Local Terraform state and plan artifacts
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log
+crash.*.log
+
+# Local variable files (never commit real secrets / project ids)
+terraform.tfvars
+*.auto.tfvars
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Editor / OS noise
+.idea/
+.vscode/
+.DS_Store

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,6 +1,7 @@
-# Local Terraform state and plan artifacts
+# Local Terraform state and plan artifacts. The provider lockfile
+# (.terraform.lock.hcl) is intentionally tracked so provider versions are
+# reproducible across machines and CI runs.
 .terraform/
-.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
 *.tfplan

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -66,19 +66,27 @@ curl "$(terraform output -raw browser_service_url)/v1/sessions" \
 
 ## How the pieces connect
 
-```
-                 ┌────────────────────┐
-                 │  browser-service   │  Cloud Run (public)
-                 │  Spring Boot API   │
-                 └────────┬───────────┘
-                          │ VPC connector (private egress)
-          ┌───────────────┼──────────────────────┐
-          │               │                      │
-          ▼               ▼                      ▼
- ┌─────────────────┐ ┌─────────────────┐   ┌───────────────────┐
- │ Cloud SQL       │ │ selenium-chrome │ … │ selenium-chrome   │
- │ Postgres (priv.)│ │  -dev-00 (Run)  │   │  -dev-09 (Run)    │
- └─────────────────┘ └─────────────────┘   └───────────────────┘
+```mermaid
+flowchart TD
+    Client([External caller])
+    API["browser-service API<br/>Spring Boot · Cloud Run<br/>ingress = all"]
+    PG[("Cloud SQL Postgres<br/>private IP")]
+    Secret[["Secret Manager<br/>DB password"]]
+    S0["selenium-chrome-dev-00<br/>Cloud Run · ingress = internal"]
+    S1["selenium-chrome-dev-01<br/>Cloud Run · ingress = internal"]
+    SN["selenium-chrome-dev-09<br/>Cloud Run · ingress = internal"]
+
+    Client -->|HTTPS| API
+
+    subgraph VPC["VPC (Serverless VPC Access connector, egress = all-traffic)"]
+        API -->|JDBC| PG
+        API -->|/wd/hub| S0
+        API -->|/wd/hub| S1
+        API -->|/wd/hub| SN
+    end
+
+    API -.reads DATABASE_PASSWORD.-> Secret
+    S1 -.- SN
 ```
 
 - The API reads `DATABASE_PASSWORD` from Secret Manager; everything else (`DATABASE_URL`, `DATABASE_USERNAME`, `SELENIUM_GRID_URLS`) is plain env injected by Terraform.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,121 @@
+# Terraform — GCP deployment for browser-service
+
+This module provisions a complete browser-service environment on Google Cloud:
+
+- **VPC** with a primary subnet, Serverless VPC Access connector, and private services access for Cloud SQL.
+- **Cloud SQL Postgres** (private IP only) plus a Secret Manager secret holding the generated password.
+- **Cloud Run × N** Selenium standalone-chrome replicas, modeled on [`LookseeIaC/GCP/modules/selenium`](https://github.com/brandonkindred/LookseeIaC/tree/main/GCP/modules/selenium).
+- **Cloud Run** browser-service Spring Boot API, wired to Postgres and to all Selenium replicas via `SELENIUM_GRID_URLS`.
+
+A single `terraform apply` brings the whole stack up: Postgres, the API, and 10 Selenium browser containers (configurable via `selenium_instance_count`).
+
+## Layout
+
+```
+terraform/
+├── main.tf                          # Wires modules + enables APIs + creates the runtime service account.
+├── variables.tf                     # Top-level input variables.
+├── outputs.tf                       # API URL, grid URLs, DB info.
+├── providers.tf
+├── versions.tf
+├── terraform.tfvars.example
+└── modules/
+    ├── vpc/                         # Network, subnet, VPC connector, private services access.
+    ├── postgres/                    # Cloud SQL Postgres (private IP) + DB password in Secret Manager.
+    ├── selenium/                    # One Cloud Run service per Selenium replica (LookseeIaC-shaped).
+    └── browser_service/             # Cloud Run service for the Spring Boot API.
+```
+
+## Prerequisites
+
+1. A GCP project with billing enabled.
+2. `gcloud auth application-default login` (or set `credentials_file` to a service account JSON).
+3. The principal running `terraform apply` needs at minimum: `roles/owner`, or a tighter combo of:
+   - `roles/serviceusage.serviceUsageAdmin`
+   - `roles/compute.networkAdmin`
+   - `roles/vpcaccess.admin`
+   - `roles/cloudsql.admin`
+   - `roles/secretmanager.admin`
+   - `roles/run.admin`
+   - `roles/iam.serviceAccountAdmin`
+   - `roles/iam.securityAdmin`
+4. A published browser-service container image — Artifact Registry, GHCR, or Docker Hub all work. Set `browser_service_image` to its pullable reference.
+
+## Usage
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars         # set project_id, image, etc.
+
+terraform init
+terraform plan
+terraform apply
+```
+
+When `apply` finishes:
+
+```bash
+terraform output browser_service_url
+# https://browser-service-api-dev-xxxxx-uc.a.run.app
+
+curl "$(terraform output -raw browser_service_url)/v1/sessions" \
+  -H 'Content-Type: application/json' \
+  -d '{"browser":"chrome","environment":"discovery"}'
+```
+
+## How the pieces connect
+
+```
+                 ┌────────────────────┐
+                 │  browser-service   │  Cloud Run (public)
+                 │  Spring Boot API   │
+                 └────────┬───────────┘
+                          │ VPC connector (private egress)
+          ┌───────────────┼──────────────────────┐
+          │               │                      │
+          ▼               ▼                      ▼
+ ┌─────────────────┐ ┌─────────────────┐   ┌───────────────────┐
+ │ Cloud SQL       │ │ selenium-chrome │ … │ selenium-chrome   │
+ │ Postgres (priv.)│ │  -dev-00 (Run)  │   │  -dev-09 (Run)    │
+ └─────────────────┘ └─────────────────┘   └───────────────────┘
+```
+
+- The API reads `DATABASE_PASSWORD` from Secret Manager; everything else (`DATABASE_URL`, `DATABASE_USERNAME`, `SELENIUM_GRID_URLS`) is plain env injected by Terraform.
+- Selenium services run with `ingress = "internal"` so they're only reachable from the VPC (the browser-service runs through the VPC connector, so it can hit them).
+- The API runs with `ingress = "all"` by default. Flip `browser_service_allow_public = false` to drop the `allUsers` invoker binding once you have auth wired up.
+
+## Variables you'll most likely change
+
+| Variable | Default | Notes |
+|---|---|---|
+| `project_id` | — | Required. |
+| `region` | `us-central1` | Cloud Run + Cloud SQL region. |
+| `environment` | `dev` | Suffixed onto resource names. |
+| `browser_service_image` | `ghcr.io/brandonkindred/browser-service:latest` | Pull spec for the API container. |
+| `selenium_instance_count` | `10` | Number of Selenium Cloud Run replicas. |
+| `selenium_image` | `selenium/standalone-chrome:4.27.0` | Override to match LookseeIaC's pinned `3.141.59` if you need legacy parity. |
+| `postgres_tier` | `db-custom-1-3840` | Bump for prod. |
+| `postgres_deletion_protection` | `true` | Set `false` in dev so `terraform destroy` works. |
+
+See `variables.tf` for the full list (autoscaling bounds, CPU/memory allocations, ingress, etc.).
+
+## Cost guardrails
+
+The default footprint isn't free:
+
+- 1 Cloud SQL Postgres `db-custom-1-3840` instance (~$50/mo idle).
+- 10 Cloud Run Selenium services with `min_instances = 1` (each holds one warm Chrome container).
+- 1 Cloud Run browser-service API with `min_instances = 1`.
+- 1 Serverless VPC Access connector (2× e2-micro).
+
+For dev / smoke testing, drop `selenium_instance_count` to `1` and set both API and Selenium `min_instances` to `0` (override in `terraform.tfvars` via the relevant variables).
+
+## Out of scope (for now)
+
+These are intentional gaps that match the MVP scope of the service itself:
+
+- No auth on the API (`browser_service_allow_public = true`). The README of the parent project covers this in the "Explicitly out of MVP" section.
+- No Cloud Armor / load balancer in front of the API — Cloud Run's default URL is the entry point.
+- No CI pipeline that pushes the container image. Build + push the image manually (or wire it up in the existing GitHub Actions workflow) and point `browser_service_image` at it.
+- No remote Terraform state backend. For shared environments, configure a GCS backend in `versions.tf` (`terraform { backend "gcs" { ... } }`).

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,6 +38,7 @@ terraform/
    - `roles/secretmanager.admin`
    - `roles/run.admin`
    - `roles/iam.serviceAccountAdmin`
+   - `roles/iam.serviceAccountUser` (needed to attach the runtime service account to Cloud Run revisions — `iam.serviceAccounts.actAs`)
    - `roles/iam.securityAdmin`
 4. A published browser-service container image — Artifact Registry, GHCR, or Docker Hub all work. Set `browser_service_image` to its pullable reference.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -60,10 +60,16 @@ When `apply` finishes:
 terraform output browser_service_url
 # https://browser-service-api-dev-xxxxx-uc.a.run.app
 
-curl "$(terraform output -raw browser_service_url)/v1/sessions" \
+curl -X POST "$(terraform output -raw browser_service_url)/v1/sessions" \
   -H 'Content-Type: application/json' \
-  -d '{"browser":"chrome","environment":"discovery"}'
+  -H 'X-Caller-Id: smoke-test' \
+  -d '{"browser_type": "CHROME", "environment": "DISCOVERY"}'
 ```
+
+Notes on the smoke-test request:
+- `X-Caller-Id` is required — every request needs a caller identifier (the API uses it for the per-caller session cap).
+- Field names are snake-case on the wire (`browser_type`, not `browser`) because the API serializes with `SNAKE_CASE`.
+- Enum values are uppercase: `BrowserType` ∈ {`CHROME`, `FIREFOX`, `SAFARI`, `IE`, `ANDROID`, `IOS`}; `BrowserEnvironment` ∈ {`TEST`, `DISCOVERY`}.
 
 ## How the pieces connect
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -98,7 +98,7 @@ flowchart TD
 
 - The API reads `DATABASE_PASSWORD` from Secret Manager; everything else (`DATABASE_URL`, `DATABASE_USERNAME`, `SELENIUM_GRID_URLS`) is plain env injected by Terraform.
 - Selenium services run with `ingress = "internal"` so they're only reachable from the VPC (the browser-service runs through the VPC connector, so it can hit them).
-- The API runs with `ingress = "all"` by default. Flip `browser_service_allow_public = false` to drop the `allUsers` invoker binding once you have auth wired up.
+- The API runs with `ingress = "all"` by default. To restrict to authenticated callers, set `browser_service_allow_public = false` **and** pass the principals you want in `browser_service_invoker_members` (e.g. `["serviceAccount:caller@your-project.iam.gserviceaccount.com"]`). With `allow_public = false` and an empty `invoker_members` list the API has no IAM bindings at all, so it's reachable on the network but every request returns 403.
 
 ## Variables you'll most likely change
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -134,3 +134,14 @@ These are intentional gaps that match the MVP scope of the service itself:
 - No Cloud Armor / load balancer in front of the API — Cloud Run's default URL is the entry point.
 - No CI pipeline that pushes the container image. Build + push the image manually (or wire it up in the existing GitHub Actions workflow) and point `browser_service_image` at it.
 - No remote Terraform state backend. For shared environments, configure a GCS backend in `versions.tf` (`terraform { backend "gcs" { ... } }`).
+
+## Secrets in Terraform state
+
+Terraform manages the DB user, the generated password, and the Secret Manager version, so the password ends up in state in three places (`random_password.db.result`, `google_sql_user.app.password`, `google_secret_manager_secret_version.db_password.secret_data`). This is inherent to provisioning credentials with Terraform; the only way to avoid it is to externalize secret generation entirely (e.g. let an out-of-band tool create the SQL user + secret and then `terraform import` them).
+
+For any non-throwaway environment:
+
+- **Use a GCS remote backend** with bucket-level IAM (read access restricted to the same principals who can run `terraform apply`).
+- **Enable bucket-level CMEK** so the state object is encrypted with a key whose access is auditable.
+- **Don't commit `terraform.tfstate*` to the repo** — `.gitignore` already excludes it.
+- **Switch to Cloud SQL IAM auth** if you want to drop the password from state entirely. That requires app-side changes (Cloud SQL JDBC connector with IAM authentication) and is out of scope for this terraform PR.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,19 +51,24 @@ module "vpc" {
 module "postgres" {
   source = "./modules/postgres"
 
-  project_id             = var.project_id
-  region                 = var.region
-  environment            = var.environment
-  network_id             = module.vpc.network_id
-  private_vpc_connection = module.vpc.private_vpc_connection
-  database_name          = var.postgres_database_name
-  database_user          = var.postgres_user
-  database_version       = var.postgres_version
-  tier                   = var.postgres_tier
-  disk_size_gb           = var.postgres_disk_size_gb
-  deletion_protection    = var.postgres_deletion_protection
-  service_account_email  = google_service_account.runtime.email
-  labels                 = local.base_labels
+  project_id            = var.project_id
+  region                = var.region
+  environment           = var.environment
+  network_id            = module.vpc.network_id
+  database_name         = var.postgres_database_name
+  database_user         = var.postgres_user
+  database_version      = var.postgres_version
+  tier                  = var.postgres_tier
+  disk_size_gb          = var.postgres_disk_size_gb
+  deletion_protection   = var.postgres_deletion_protection
+  service_account_email = google_service_account.runtime.email
+  labels                = local.base_labels
+
+  # The Cloud SQL instance can't be created until private services access
+  # is established on the VPC. Depending on the whole module (rather than
+  # threading the service-networking-connection id through a variable)
+  # keeps the dependency a real Terraform graph edge.
+  depends_on = [module.vpc]
 }
 
 # Fan out N Selenium standalone-chrome Cloud Run services. Each is the same

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,6 +7,12 @@ locals {
     },
     var.labels,
   )
+
+  # Default network names include `environment` so multiple stacks can share a
+  # project without collisions. tfvars can still override any of these.
+  vpc_name           = coalesce(var.vpc_name, "browser-service-vpc-${var.environment}")
+  subnet_name        = coalesce(var.subnet_name, "browser-service-subnet-${var.environment}")
+  vpc_connector_name = coalesce(var.vpc_connector_name, "browser-service-conn-${var.environment}")
 }
 
 # Enable APIs the stack depends on. Idempotent; safe to leave on.
@@ -40,10 +46,13 @@ resource "google_service_account" "runtime" {
 module "vpc" {
   source = "./modules/vpc"
 
-  project_id  = var.project_id
-  region      = var.region
-  vpc_name    = var.vpc_name
-  subnet_cidr = var.subnet_cidr
+  project_id     = var.project_id
+  region         = var.region
+  vpc_name       = local.vpc_name
+  subnet_name    = local.subnet_name
+  connector_name = local.vpc_connector_name
+  subnet_cidr    = var.subnet_cidr
+  enable_nat     = var.vpc_enable_nat
 
   depends_on = [google_project_service.required]
 }
@@ -88,7 +97,9 @@ module "selenium" {
   port                  = var.selenium_port
   memory_allocation     = var.selenium_memory_allocation
   cpu_allocation        = var.selenium_cpu_allocation
-  ingress = "internal"
+  min_instances         = var.selenium_min_instances
+  max_instances         = var.selenium_max_instances
+  ingress               = "internal"
   # Selenium speaks plain HTTP, not GCP id-token auth, so invoker auth would
   # block the Java client. Pair allUsers with ingress=internal: the IAM check
   # passes once traffic is on the VPC, and ingress=internal keeps the public

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,120 @@
+locals {
+  base_labels = merge(
+    {
+      app         = "browser-service"
+      environment = var.environment
+      managed-by  = "terraform"
+    },
+    var.labels,
+  )
+}
+
+# Enable APIs the stack depends on. Idempotent; safe to leave on.
+resource "google_project_service" "required" {
+  for_each = toset([
+    "compute.googleapis.com",
+    "run.googleapis.com",
+    "vpcaccess.googleapis.com",
+    "sqladmin.googleapis.com",
+    "secretmanager.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "iam.googleapis.com",
+  ])
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# Single runtime service account used by the browser-service API and the
+# Selenium Cloud Run replicas. Keeping it shared simplifies IAM since the API
+# already needs to invoke each Selenium peer.
+resource "google_service_account" "runtime" {
+  project      = var.project_id
+  account_id   = "browser-service-${var.environment}"
+  display_name = "Browser Service runtime (${var.environment})"
+
+  depends_on = [google_project_service.required]
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+
+  project_id  = var.project_id
+  region      = var.region
+  vpc_name    = var.vpc_name
+  subnet_cidr = var.subnet_cidr
+
+  depends_on = [google_project_service.required]
+}
+
+module "postgres" {
+  source = "./modules/postgres"
+
+  project_id             = var.project_id
+  region                 = var.region
+  environment            = var.environment
+  network_id             = module.vpc.network_id
+  private_vpc_connection = module.vpc.private_vpc_connection
+  database_name          = var.postgres_database_name
+  database_user          = var.postgres_user
+  database_version       = var.postgres_version
+  tier                   = var.postgres_tier
+  disk_size_gb           = var.postgres_disk_size_gb
+  deletion_protection    = var.postgres_deletion_protection
+  service_account_email  = google_service_account.runtime.email
+  labels                 = local.base_labels
+}
+
+# Fan out N Selenium standalone-chrome Cloud Run services. Each is the same
+# pattern as LookseeIaC/GCP/modules/selenium, just provisioned `count` times
+# with a stable per-replica name.
+module "selenium" {
+  source = "./modules/selenium"
+  count  = var.selenium_instance_count
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = var.environment
+  service_name          = "selenium-chrome-${var.environment}-${format("%02d", count.index)}"
+  image                 = var.selenium_image
+  service_account_email = google_service_account.runtime.email
+  vpc_connector_name    = module.vpc.vpc_connector_name
+  port                  = var.selenium_port
+  memory_allocation     = var.selenium_memory_allocation
+  cpu_allocation        = var.selenium_cpu_allocation
+  ingress = "internal"
+  # Selenium speaks plain HTTP, not GCP id-token auth, so invoker auth would
+  # block the Java client. Pair allUsers with ingress=internal: the IAM check
+  # passes once traffic is on the VPC, and ingress=internal keeps the public
+  # internet out.
+  invoker_members = ["allUsers"]
+  labels          = local.base_labels
+}
+
+module "browser_service" {
+  source = "./modules/browser_service"
+
+  project_id            = var.project_id
+  region                = var.region
+  service_name          = "${var.browser_service_service_name}-${var.environment}"
+  image                 = var.browser_service_image
+  service_account_email = google_service_account.runtime.email
+  vpc_connector_name    = module.vpc.vpc_connector_name
+  min_instances         = var.browser_service_min_instances
+  max_instances         = var.browser_service_max_instances
+  memory                = var.browser_service_memory
+  cpu                   = var.browser_service_cpu
+  allow_public          = var.browser_service_allow_public
+
+  database_url                  = "jdbc:postgresql://${module.postgres.private_ip_address}:5432/${module.postgres.database_name}"
+  database_username             = module.postgres.database_user
+  database_password_secret_name = module.postgres.password_secret_name
+
+  selenium_grid_urls = [for s in module.selenium : s.grid_endpoint]
+
+  labels = local.base_labels
+
+  # Make sure secret access IAM is in place before the service tries to read it.
+  depends_on = [module.postgres]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -136,10 +136,12 @@ module "browser_service" {
   memory                = var.browser_service_memory
   cpu                   = var.browser_service_cpu
   allow_public          = var.browser_service_allow_public
+  invoker_members       = var.browser_service_invoker_members
 
-  database_url                  = "jdbc:postgresql://${module.postgres.private_ip_address}:5432/${module.postgres.database_name}"
-  database_username             = module.postgres.database_user
-  database_password_secret_name = module.postgres.password_secret_name
+  database_url                     = "jdbc:postgresql://${module.postgres.private_ip_address}:5432/${module.postgres.database_name}"
+  database_username                = module.postgres.database_user
+  database_password_secret_name    = module.postgres.password_secret_name
+  database_password_secret_version = module.postgres.password_secret_version_number
 
   selenium_grid_urls = [for s in module.selenium : s.grid_host]
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,6 +66,7 @@ module "vpc" {
   subnet_name    = local.subnet_name
   connector_name = local.vpc_connector_name
   subnet_cidr    = var.subnet_cidr
+  connector_cidr = var.connector_cidr
 
   depends_on = [google_project_service.required]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,7 +66,6 @@ module "vpc" {
   subnet_name    = local.subnet_name
   connector_name = local.vpc_connector_name
   subnet_cidr    = var.subnet_cidr
-  enable_nat     = var.vpc_enable_nat
 
   depends_on = [google_project_service.required]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -127,7 +127,7 @@ module "browser_service" {
   database_username             = module.postgres.database_user
   database_password_secret_name = module.postgres.password_secret_name
 
-  selenium_grid_urls = [for s in module.selenium : s.grid_endpoint]
+  selenium_grid_urls = [for s in module.selenium : s.grid_host]
 
   labels = local.base_labels
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,7 +12,10 @@ locals {
   # project without collisions. tfvars can still override any of these.
   vpc_name           = coalesce(var.vpc_name, "browser-service-vpc-${var.environment}")
   subnet_name        = coalesce(var.subnet_name, "browser-service-subnet-${var.environment}")
-  vpc_connector_name = coalesce(var.vpc_connector_name, "browser-service-conn-${var.environment}")
+  # Serverless VPC Access connector names are capped at 25 chars, so this
+  # default uses a short prefix. The `environment` variable is validated at
+  # 12 chars, which keeps `bs-conn-<env>` (8 + env) safely under the limit.
+  vpc_connector_name = coalesce(var.vpc_connector_name, "bs-conn-${var.environment}")
 }
 
 # Enable APIs the stack depends on. Idempotent; safe to leave on.
@@ -25,6 +28,7 @@ resource "google_project_service" "required" {
     "secretmanager.googleapis.com",
     "servicenetworking.googleapis.com",
     "iam.googleapis.com",
+    "artifactregistry.googleapis.com",
   ])
 
   project            = var.project_id
@@ -32,13 +36,23 @@ resource "google_project_service" "required" {
   disable_on_destroy = false
 }
 
-# Single runtime service account used by the browser-service API and the
-# Selenium Cloud Run replicas. Keeping it shared simplifies IAM since the API
-# already needs to invoke each Selenium peer.
-resource "google_service_account" "runtime" {
+# Two runtime service accounts so least-privilege holds: only the API SA
+# needs Secret Manager access for the DB password (granted by the postgres
+# module), while Selenium replicas run with a separate identity that has no
+# privileged role bindings. If a Selenium container is compromised, DB
+# credentials don't come along for free.
+resource "google_service_account" "api_runtime" {
   project      = var.project_id
-  account_id   = "browser-service-${var.environment}"
-  display_name = "Browser Service runtime (${var.environment})"
+  account_id   = "bs-api-${var.environment}"
+  display_name = "Browser Service API runtime (${var.environment})"
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_service_account" "selenium_runtime" {
+  project      = var.project_id
+  account_id   = "bs-selenium-${var.environment}"
+  display_name = "Browser Service Selenium runtime (${var.environment})"
 
   depends_on = [google_project_service.required]
 }
@@ -70,7 +84,7 @@ module "postgres" {
   tier                  = var.postgres_tier
   disk_size_gb          = var.postgres_disk_size_gb
   deletion_protection   = var.postgres_deletion_protection
-  service_account_email = google_service_account.runtime.email
+  service_account_email = google_service_account.api_runtime.email
   labels                = local.base_labels
 
   # The Cloud SQL instance can't be created until private services access
@@ -92,7 +106,7 @@ module "selenium" {
   environment           = var.environment
   service_name          = "selenium-chrome-${var.environment}-${format("%02d", count.index)}"
   image                 = var.selenium_image
-  service_account_email = google_service_account.runtime.email
+  service_account_email = google_service_account.selenium_runtime.email
   vpc_connector_name    = module.vpc.vpc_connector_name
   port                  = var.selenium_port
   memory_allocation     = var.selenium_memory_allocation
@@ -101,10 +115,11 @@ module "selenium" {
   max_instances         = var.selenium_max_instances
   ingress               = "internal"
   # Selenium speaks plain HTTP, not GCP id-token auth, so invoker auth would
-  # block the Java client. Pair allUsers with ingress=internal: the IAM check
-  # passes once traffic is on the VPC, and ingress=internal keeps the public
-  # internet out.
-  invoker_members = ["allUsers"]
+  # block the Java client. The default `["allUsers"]` paired with
+  # ingress=internal keeps the public internet out while letting in-VPC
+  # callers reach the service. In orgs that block allUsers via
+  # iam.allowedPolicyMemberDomains, set selenium_invoker_members = [].
+  invoker_members = var.selenium_invoker_members
   labels          = local.base_labels
 }
 
@@ -115,7 +130,7 @@ module "browser_service" {
   region                = var.region
   service_name          = "${var.browser_service_service_name}-${var.environment}"
   image                 = var.browser_service_image
-  service_account_email = google_service_account.runtime.email
+  service_account_email = google_service_account.api_runtime.email
   vpc_connector_name    = module.vpc.vpc_connector_name
   min_instances         = var.browser_service_min_instances
   max_instances         = var.browser_service_max_instances

--- a/terraform/modules/browser_service/main.tf
+++ b/terraform/modules/browser_service/main.tf
@@ -1,0 +1,103 @@
+resource "google_cloud_run_service" "api" {
+  name     = var.service_name
+  location = var.region
+  project  = var.project_id
+
+  metadata {
+    annotations = {
+      "run.googleapis.com/ingress"     = var.ingress
+      "run.googleapis.com/client-name" = "terraform"
+    }
+    labels = var.labels
+  }
+
+  template {
+    metadata {
+      annotations = {
+        "run.googleapis.com/vpc-access-connector" = var.vpc_connector_name
+        # all-traffic so calls to internal-ingress Selenium services traverse
+        # the VPC (otherwise the public *.run.app URL is reached over the
+        # internet and rejected by ingress=internal).
+        "run.googleapis.com/vpc-access-egress" = "all-traffic"
+        "autoscaling.knative.dev/minScale"        = tostring(var.min_instances)
+        "autoscaling.knative.dev/maxScale"        = tostring(var.max_instances)
+      }
+    }
+
+    spec {
+      service_account_name  = var.service_account_email
+      timeout_seconds       = var.request_timeout_seconds
+      container_concurrency = var.container_concurrency
+
+      containers {
+        image = var.image
+
+        ports {
+          container_port = var.port
+        }
+
+        resources {
+          limits = {
+            memory = var.memory
+            cpu    = var.cpu
+          }
+        }
+
+        env {
+          name  = "DATABASE_URL"
+          value = var.database_url
+        }
+
+        env {
+          name  = "DATABASE_USERNAME"
+          value = var.database_username
+        }
+
+        env {
+          name = "DATABASE_PASSWORD"
+          value_from {
+            secret_key_ref {
+              name = var.database_password_secret_name
+              key  = "latest"
+            }
+          }
+        }
+
+        env {
+          name  = "SELENIUM_GRID_URLS"
+          value = join(",", var.selenium_grid_urls)
+        }
+
+        dynamic "env" {
+          for_each = var.extra_env
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["run.googleapis.com/operation-id"],
+      template[0].metadata[0].annotations["run.googleapis.com/operation-id"],
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "public" {
+  count = var.allow_public ? 1 : 0
+
+  location = google_cloud_run_service.api.location
+  project  = google_cloud_run_service.api.project
+  service  = google_cloud_run_service.api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/terraform/modules/browser_service/main.tf
+++ b/terraform/modules/browser_service/main.tf
@@ -58,7 +58,7 @@ resource "google_cloud_run_service" "api" {
           value_from {
             secret_key_ref {
               name = var.database_password_secret_name
-              key  = "latest"
+              key  = var.database_password_secret_version
             }
           }
         }
@@ -100,4 +100,14 @@ resource "google_cloud_run_service_iam_member" "public" {
   service  = google_cloud_run_service.api.name
   role     = "roles/run.invoker"
   member   = "allUsers"
+}
+
+resource "google_cloud_run_service_iam_member" "invoker" {
+  for_each = toset(var.invoker_members)
+
+  location = google_cloud_run_service.api.location
+  project  = google_cloud_run_service.api.project
+  service  = google_cloud_run_service.api.name
+  role     = "roles/run.invoker"
+  member   = each.value
 }

--- a/terraform/modules/browser_service/main.tf
+++ b/terraform/modules/browser_service/main.tf
@@ -103,7 +103,10 @@ resource "google_cloud_run_service_iam_member" "public" {
 }
 
 resource "google_cloud_run_service_iam_member" "invoker" {
-  for_each = toset(var.invoker_members)
+  # Filter out allUsers when allow_public is true — it's already bound by
+  # the resource above, and binding the same member/role twice causes a
+  # plan-time IAM conflict.
+  for_each = toset([for m in var.invoker_members : m if !(var.allow_public && m == "allUsers")])
 
   location = google_cloud_run_service.api.location
   project  = google_cloud_run_service.api.project

--- a/terraform/modules/browser_service/outputs.tf
+++ b/terraform/modules/browser_service/outputs.tf
@@ -1,0 +1,9 @@
+output "service_url" {
+  description = "Public URL of the browser-service API."
+  value       = google_cloud_run_service.api.status[0].url
+}
+
+output "service_name" {
+  description = "Cloud Run service name for the browser-service API."
+  value       = google_cloud_run_service.api.name
+}

--- a/terraform/modules/browser_service/variables.tf
+++ b/terraform/modules/browser_service/variables.tf
@@ -1,0 +1,115 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Cloud Run service."
+  type        = string
+}
+
+variable "service_name" {
+  description = "Cloud Run service name."
+  type        = string
+}
+
+variable "image" {
+  description = "Container image for the browser-service Spring Boot API."
+  type        = string
+}
+
+variable "port" {
+  description = "Container port the Spring Boot app listens on (matches application.yaml server.port)."
+  type        = number
+  default     = 8080
+}
+
+variable "service_account_email" {
+  description = "Runtime service account email."
+  type        = string
+}
+
+variable "vpc_connector_name" {
+  description = "Serverless VPC Access connector name (so Cloud Run can reach Cloud SQL private IP and internal Selenium services)."
+  type        = string
+}
+
+variable "min_instances" {
+  description = "Minimum warm Cloud Run instances."
+  type        = number
+  default     = 1
+}
+
+variable "max_instances" {
+  description = "Maximum Cloud Run instances."
+  type        = number
+  default     = 10
+}
+
+variable "container_concurrency" {
+  description = "Max concurrent requests per container."
+  type        = number
+  default     = 80
+}
+
+variable "request_timeout_seconds" {
+  description = "Cloud Run per-request timeout. Browser sessions may take a while to set up."
+  type        = number
+  default     = 600
+}
+
+variable "memory" {
+  description = "Memory limit for the container (e.g. 1Gi, 2Gi)."
+  type        = string
+  default     = "2Gi"
+}
+
+variable "cpu" {
+  description = "CPU limit for the container."
+  type        = string
+  default     = "2"
+}
+
+variable "ingress" {
+  description = "Cloud Run ingress: 'all', 'internal', or 'internal-and-cloud-load-balancing'."
+  type        = string
+  default     = "all"
+}
+
+variable "allow_public" {
+  description = "If true, grants roles/run.invoker to allUsers (public API). MVP runs without auth, so this is the default."
+  type        = bool
+  default     = true
+}
+
+variable "database_url" {
+  description = "JDBC URL for the application database (e.g. jdbc:postgresql://10.x.x.x:5432/browser_service)."
+  type        = string
+}
+
+variable "database_username" {
+  description = "Database username."
+  type        = string
+}
+
+variable "database_password_secret_name" {
+  description = "Short name of the Secret Manager secret that holds the DB password."
+  type        = string
+}
+
+variable "selenium_grid_urls" {
+  description = "List of Selenium grid URLs (each ending in /wd/hub). Joined with commas into SELENIUM_GRID_URLS."
+  type        = list(string)
+}
+
+variable "extra_env" {
+  description = "Additional plain (non-secret) environment variables to inject into the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Labels to apply to the Cloud Run service."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/browser_service/variables.tf
+++ b/terraform/modules/browser_service/variables.tf
@@ -82,6 +82,12 @@ variable "allow_public" {
   default     = true
 }
 
+variable "invoker_members" {
+  description = "Additional IAM principals granted roles/run.invoker on the API. Useful when `allow_public = false` to grant specific service accounts / groups."
+  type        = list(string)
+  default     = []
+}
+
 variable "database_url" {
   description = "JDBC URL for the application database (e.g. jdbc:postgresql://10.x.x.x:5432/browser_service)."
   type        = string
@@ -94,6 +100,11 @@ variable "database_username" {
 
 variable "database_password_secret_name" {
   description = "Short name of the Secret Manager secret that holds the DB password."
+  type        = string
+}
+
+variable "database_password_secret_version" {
+  description = "Specific Secret Manager version (e.g. \"1\") of the DB password secret. Pinning to a version (not 'latest') keeps Cloud Run's mounted credential in lock-step with the password Terraform created — a stray manual `secret-version add` won't silently break the API's auth."
   type        = string
 }
 

--- a/terraform/modules/browser_service/variables.tf
+++ b/terraform/modules/browser_service/variables.tf
@@ -98,7 +98,7 @@ variable "database_password_secret_name" {
 }
 
 variable "selenium_grid_urls" {
-  description = "List of Selenium grid URLs (each ending in /wd/hub). Joined with commas into SELENIUM_GRID_URLS."
+  description = "List of bare Selenium hostnames (no scheme, no path) joined with commas into SELENIUM_GRID_URLS. The engine's BrowserConnectionHelper prepends https:// and appends /wd/hub at runtime, so passing fully-qualified URLs would yield https://https://.../wd/hub/wd/hub."
   type        = list(string)
 }
 

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -20,6 +20,13 @@ resource "google_sql_database_instance" "this" {
     disk_autoresize   = true
     availability_type = var.availability_type
 
+    # Cloud SQL has TWO deletion protections. The top-level
+    # `deletion_protection` (Terraform-side) only blocks `terraform destroy`;
+    # this `deletion_protection_enabled` is the server-side flag that also
+    # blocks deletes from gcloud / the Cloud Console. Both follow the same
+    # var so prod can't be wiped via either path.
+    deletion_protection_enabled = var.deletion_protection
+
     backup_configuration {
       enabled                        = true
       point_in_time_recovery_enabled = true

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -1,0 +1,77 @@
+resource "random_password" "db" {
+  length  = 32
+  special = true
+  # Cloud SQL accepts most special chars but exclude ones that complicate
+  # JDBC URLs and shell quoting downstream.
+  override_special = "-_=+"
+}
+
+resource "google_sql_database_instance" "this" {
+  name                = "${var.instance_name}-${var.environment}"
+  region              = var.region
+  database_version    = var.database_version
+  project             = var.project_id
+  deletion_protection = var.deletion_protection
+
+  depends_on = [var.private_vpc_connection]
+
+  settings {
+    tier              = var.tier
+    disk_size         = var.disk_size_gb
+    disk_type         = "PD_SSD"
+    disk_autoresize   = true
+    availability_type = var.availability_type
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+      start_time                     = "03:00"
+    }
+
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = var.network_id
+      enable_private_path_for_google_cloud_services = true
+    }
+
+    user_labels = var.labels
+  }
+}
+
+resource "google_sql_database" "app" {
+  name     = var.database_name
+  instance = google_sql_database_instance.this.name
+  project  = var.project_id
+}
+
+resource "google_sql_user" "app" {
+  name     = var.database_user
+  instance = google_sql_database_instance.this.name
+  password = random_password.db.result
+  project  = var.project_id
+}
+
+# Store the generated password in Secret Manager so the Cloud Run service can
+# mount it as an env var without leaking it through Terraform state outputs.
+resource "google_secret_manager_secret" "db_password" {
+  secret_id = "${var.instance_name}-${var.environment}-db-password"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = var.labels
+}
+
+resource "google_secret_manager_secret_version" "db_password" {
+  secret      = google_secret_manager_secret.db_password.id
+  secret_data = random_password.db.result
+}
+
+resource "google_secret_manager_secret_iam_member" "accessor" {
+  secret_id = google_secret_manager_secret.db_password.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.service_account_email}"
+  project   = var.project_id
+}

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -13,8 +13,6 @@ resource "google_sql_database_instance" "this" {
   project             = var.project_id
   deletion_protection = var.deletion_protection
 
-  depends_on = [var.private_vpc_connection]
-
   settings {
     tier              = var.tier
     disk_size         = var.disk_size_gb

--- a/terraform/modules/postgres/outputs.tf
+++ b/terraform/modules/postgres/outputs.tf
@@ -37,3 +37,8 @@ output "password_secret_version" {
   description = "Specific version id of the Secret Manager secret created in this run."
   value       = google_secret_manager_secret_version.db_password.id
 }
+
+output "password_secret_version_number" {
+  description = "Version number (e.g. \"1\") of the Secret Manager secret created in this run. Pinned by callers so a stray secret-version add doesn't desync the runtime credential."
+  value       = google_secret_manager_secret_version.db_password.version
+}

--- a/terraform/modules/postgres/outputs.tf
+++ b/terraform/modules/postgres/outputs.tf
@@ -1,0 +1,39 @@
+output "instance_name" {
+  description = "Cloud SQL instance name."
+  value       = google_sql_database_instance.this.name
+}
+
+output "connection_name" {
+  description = "Cloud SQL connection name (project:region:instance)."
+  value       = google_sql_database_instance.this.connection_name
+}
+
+output "private_ip_address" {
+  description = "Private IP address of the Cloud SQL instance, reachable from the VPC connector."
+  value       = google_sql_database_instance.this.private_ip_address
+}
+
+output "database_name" {
+  description = "Application database name."
+  value       = google_sql_database.app.name
+}
+
+output "database_user" {
+  description = "Application database user."
+  value       = google_sql_user.app.name
+}
+
+output "password_secret_name" {
+  description = "Short name of the Secret Manager secret holding the DB password."
+  value       = google_secret_manager_secret.db_password.secret_id
+}
+
+output "password_secret_id" {
+  description = "Full resource id of the Secret Manager secret holding the DB password."
+  value       = google_secret_manager_secret.db_password.id
+}
+
+output "password_secret_version" {
+  description = "Specific version id of the Secret Manager secret created in this run."
+  value       = google_secret_manager_secret_version.db_password.id
+}

--- a/terraform/modules/postgres/variables.tf
+++ b/terraform/modules/postgres/variables.tf
@@ -47,11 +47,6 @@ variable "network_id" {
   type        = string
 }
 
-variable "private_vpc_connection" {
-  description = "Service networking connection id (depends_on hook so private IP is reachable before the SQL instance is created)."
-  type        = string
-}
-
 variable "database_name" {
   description = "Application database name."
   type        = string

--- a/terraform/modules/postgres/variables.tf
+++ b/terraform/modules/postgres/variables.tf
@@ -1,0 +1,80 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Cloud SQL instance."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment label, used in resource naming."
+  type        = string
+}
+
+variable "instance_name" {
+  description = "Base name for the Cloud SQL instance (environment is appended)."
+  type        = string
+  default     = "browser-service-pg"
+}
+
+variable "database_version" {
+  description = "Cloud SQL Postgres engine version (e.g. POSTGRES_17)."
+  type        = string
+  default     = "POSTGRES_17"
+}
+
+variable "tier" {
+  description = "Cloud SQL machine tier."
+  type        = string
+}
+
+variable "disk_size_gb" {
+  description = "Initial disk size in GB."
+  type        = number
+  default     = 20
+}
+
+variable "availability_type" {
+  description = "ZONAL for single-zone (cheaper) or REGIONAL for HA."
+  type        = string
+  default     = "ZONAL"
+}
+
+variable "network_id" {
+  description = "VPC network self-link / id used for private IP."
+  type        = string
+}
+
+variable "private_vpc_connection" {
+  description = "Service networking connection id (depends_on hook so private IP is reachable before the SQL instance is created)."
+  type        = string
+}
+
+variable "database_name" {
+  description = "Application database name."
+  type        = string
+}
+
+variable "database_user" {
+  description = "Application database user."
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "Email of the runtime service account that needs read access to the generated password secret."
+  type        = string
+}
+
+variable "deletion_protection" {
+  description = "Whether Cloud SQL deletion protection is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "labels" {
+  description = "Labels to apply to the Cloud SQL instance and secrets."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/selenium/main.tf
+++ b/terraform/modules/selenium/main.tf
@@ -1,0 +1,88 @@
+# Cloud Run service for a single Selenium standalone-chrome instance.
+# Modeled directly on LookseeIaC/GCP/modules/selenium/main.tf so the deploy
+# pattern (one Cloud Run service per Selenium replica, fronted by HTTPS) stays
+# consistent across projects.
+resource "google_cloud_run_service" "selenium_standalone_chrome" {
+  name     = var.service_name
+  location = var.region
+  project  = var.project_id
+
+  metadata {
+    annotations = {
+      "run.googleapis.com/ingress"     = var.ingress
+      "run.googleapis.com/client-name" = "terraform"
+    }
+    labels = var.labels
+  }
+
+  template {
+    metadata {
+      annotations = {
+        "run.googleapis.com/vpc-access-connector" = var.vpc_connector_name
+        "run.googleapis.com/vpc-access-egress"    = "private-ranges-only"
+        "autoscaling.knative.dev/minScale"        = tostring(var.min_instances)
+        "autoscaling.knative.dev/maxScale"        = tostring(var.max_instances)
+      }
+    }
+
+    spec {
+      service_account_name = var.service_account_email
+      timeout_seconds      = var.request_timeout_seconds
+      container_concurrency = var.container_concurrency
+
+      containers {
+        image = var.image
+
+        ports {
+          container_port = var.port
+        }
+
+        resources {
+          limits = {
+            memory = var.memory_allocation
+            cpu    = var.cpu_allocation
+          }
+        }
+
+        # Selenium 4 uses the /status endpoint for liveness, but Cloud Run
+        # only requires the container to listen on $PORT — the standalone
+        # image already does that on 4444. Extra env left as a hook.
+        dynamic "env" {
+          for_each = var.environment_variables
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Cloud Run mutates these on its own (revisions, generated names);
+      # skipping them avoids spurious diffs on every plan.
+      metadata[0].annotations["run.googleapis.com/operation-id"],
+      template[0].metadata[0].annotations["run.googleapis.com/operation-id"],
+    ]
+  }
+}
+
+# When ingress=internal we still need an IAM binding for the runtime SA to
+# invoke peer Selenium services. Granting `allUsers` in combination with
+# internal ingress means "anyone reachable on the VPC network", which is the
+# pragmatic Selenium-grid pattern (Selenium speaks plain HTTP, not GCP auth).
+resource "google_cloud_run_service_iam_member" "invoker" {
+  for_each = toset(var.invoker_members)
+
+  location = google_cloud_run_service.selenium_standalone_chrome.location
+  project  = google_cloud_run_service.selenium_standalone_chrome.project
+  service  = google_cloud_run_service.selenium_standalone_chrome.name
+  role     = "roles/run.invoker"
+  member   = each.value
+}

--- a/terraform/modules/selenium/outputs.tf
+++ b/terraform/modules/selenium/outputs.tf
@@ -1,0 +1,14 @@
+output "service_url" {
+  description = "URL of the Selenium Cloud Run service."
+  value       = google_cloud_run_service.selenium_standalone_chrome.status[0].url
+}
+
+output "service_name" {
+  description = "Name of the Selenium Cloud Run service."
+  value       = google_cloud_run_service.selenium_standalone_chrome.name
+}
+
+output "grid_endpoint" {
+  description = "Selenium 4 grid endpoint (service URL + /wd/hub) ready for SELENIUM_GRID_URLS."
+  value       = "${google_cloud_run_service.selenium_standalone_chrome.status[0].url}/wd/hub"
+}

--- a/terraform/modules/selenium/outputs.tf
+++ b/terraform/modules/selenium/outputs.tf
@@ -8,7 +8,12 @@ output "service_name" {
   value       = google_cloud_run_service.selenium_standalone_chrome.name
 }
 
-output "grid_endpoint" {
-  description = "Selenium 4 grid endpoint (service URL + /wd/hub) ready for SELENIUM_GRID_URLS."
-  value       = "${google_cloud_run_service.selenium_standalone_chrome.status[0].url}/wd/hub"
+output "grid_host" {
+  # The engine's BrowserConnectionHelper#getConnection builds Selenium URLs as
+  # `https://<entry>/wd/hub`, so SELENIUM_GRID_URLS entries must be bare
+  # hostnames (no scheme, no path). Cloud Run terminates TLS at the public
+  # *.run.app hostname on port 443, which matches the engine's hardcoded
+  # `https://`.
+  description = "Bare Selenium host (no scheme, no path) suitable for SELENIUM_GRID_URLS. The engine prepends https:// and appends /wd/hub at runtime."
+  value       = trimprefix(google_cloud_run_service.selenium_standalone_chrome.status[0].url, "https://")
 }

--- a/terraform/modules/selenium/variables.tf
+++ b/terraform/modules/selenium/variables.tf
@@ -1,0 +1,99 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the Cloud Run service."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment label."
+  type        = string
+}
+
+variable "service_name" {
+  description = "Cloud Run service name. Must be unique per region/project."
+  type        = string
+}
+
+variable "image" {
+  description = "Selenium standalone-chrome container image."
+  type        = string
+  default     = "selenium/standalone-chrome:4.27.0"
+}
+
+variable "service_account_email" {
+  description = "Runtime service account email used by the Cloud Run revision."
+  type        = string
+}
+
+variable "vpc_connector_name" {
+  description = "Serverless VPC Access connector name. Required so the browser-service can reach Selenium over the private VPC."
+  type        = string
+}
+
+variable "port" {
+  description = "Container port that Selenium listens on."
+  type        = number
+  default     = 4444
+}
+
+variable "memory_allocation" {
+  description = "Memory limit for the Selenium container."
+  type        = string
+}
+
+variable "cpu_allocation" {
+  description = "CPU limit for the Selenium container."
+  type        = string
+}
+
+variable "min_instances" {
+  description = "Minimum warm Cloud Run instances. Selenium standalone benefits from min_instances=1 because cold starts include Chrome boot."
+  type        = number
+  default     = 1
+}
+
+variable "max_instances" {
+  description = "Maximum Cloud Run instances. Selenium standalone serves a single session per container; keep this low (1-2)."
+  type        = number
+  default     = 1
+}
+
+variable "container_concurrency" {
+  description = "Max concurrent requests per Selenium container. Selenium standalone-chrome handles 1 session at a time."
+  type        = number
+  default     = 1
+}
+
+variable "request_timeout_seconds" {
+  description = "Cloud Run per-request timeout. Long-running Selenium operations need plenty of headroom."
+  type        = number
+  default     = 900
+}
+
+variable "ingress" {
+  description = "Cloud Run ingress: 'all', 'internal', or 'internal-and-cloud-load-balancing'."
+  type        = string
+  default     = "internal"
+}
+
+variable "invoker_members" {
+  description = "IAM members granted roles/run.invoker on this service (e.g. ['serviceAccount:browser-service@PROJECT.iam.gserviceaccount.com'])."
+  type        = list(string)
+  default     = []
+}
+
+variable "environment_variables" {
+  description = "Extra environment variables to inject into the Selenium container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Labels to apply to the Cloud Run service."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -75,12 +75,10 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 }
 
 # Cloud Router + Cloud NAT so traffic that leaves the VPC connector can reach
-# the public internet. Without this, browser-service runs with
-# vpc-access-egress=all-traffic but has no egress path for non-Google public
-# endpoints (BrowserStack, external webhooks, etc.) and those calls time out.
+# the public internet. browser-service always runs with
+# vpc-access-egress=all-traffic and reaches Selenium via public *.run.app
+# URLs, so NAT is non-optional for this stack.
 resource "google_compute_router" "router" {
-  count = var.enable_nat ? 1 : 0
-
   name    = "${var.vpc_name}-router"
   region  = var.region
   network = google_compute_network.vpc.id
@@ -88,10 +86,8 @@ resource "google_compute_router" "router" {
 }
 
 resource "google_compute_router_nat" "nat" {
-  count = var.enable_nat ? 1 : 0
-
   name                               = "${var.vpc_name}-nat"
-  router                             = google_compute_router.router[0].name
+  router                             = google_compute_router.router.name
   region                             = var.region
   project                            = var.project_id
   nat_ip_allocate_option             = "AUTO_ONLY"

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -56,3 +56,32 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_range.name]
 }
+
+# Cloud Router + Cloud NAT so traffic that leaves the VPC connector can reach
+# the public internet. Without this, browser-service runs with
+# vpc-access-egress=all-traffic but has no egress path for non-Google public
+# endpoints (BrowserStack, external webhooks, etc.) and those calls time out.
+resource "google_compute_router" "router" {
+  count = var.enable_nat ? 1 : 0
+
+  name    = "${var.vpc_name}-router"
+  region  = var.region
+  network = google_compute_network.vpc.id
+  project = var.project_id
+}
+
+resource "google_compute_router_nat" "nat" {
+  count = var.enable_nat ? 1 : 0
+
+  name                               = "${var.vpc_name}-nat"
+  router                             = google_compute_router.router[0].name
+  region                             = var.region
+  project                            = var.project_id
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = false
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -14,11 +14,28 @@ resource "google_compute_subnetwork" "subnet" {
   private_ip_google_access = true
 }
 
-resource "google_vpc_access_connector" "connector" {
-  name          = var.connector_name
-  region        = var.region
-  network       = google_compute_network.vpc.name
+# Dedicated /28 subnet for the Serverless VPC Access connector. We explicitly
+# create the subnet (rather than letting the connector auto-create a hidden
+# one via `ip_cidr_range`) because Cloud NAT cannot apply to hidden connector
+# subnets — without this, the Cloud NAT below would never see connector
+# traffic and `egress=all-traffic` workloads (the browser-service API) would
+# have no outbound path to public non-Google endpoints.
+resource "google_compute_subnetwork" "connector" {
+  name          = "${var.connector_name}-subnet"
   ip_cidr_range = var.connector_cidr
+  region        = var.region
+  network       = google_compute_network.vpc.id
+  project       = var.project_id
+}
+
+resource "google_vpc_access_connector" "connector" {
+  name   = var.connector_name
+  region = var.region
+
+  subnet {
+    name = google_compute_subnetwork.connector.name
+  }
+
   min_instances = 2
   max_instances = 3
   machine_type  = "e2-micro"

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -26,6 +26,13 @@ resource "google_compute_subnetwork" "connector" {
   region        = var.region
   network       = google_compute_network.vpc.id
   project       = var.project_id
+
+  # Required for Cloud Run-to-Cloud Run calls with ingress=internal: the
+  # caller must route through the VPC connector AND the connector subnet
+  # needs PGA so traffic to *.run.app resolves to Google's private network
+  # (not the public internet via Cloud NAT). Without it, Selenium services
+  # see the request as external and reject it with 403.
+  private_ip_google_access = true
 }
 
 resource "google_vpc_access_connector" "connector" {

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,58 @@
+resource "google_compute_network" "vpc" {
+  name                    = var.vpc_name
+  description             = "Browser service VPC network"
+  auto_create_subnetworks = false
+  project                 = var.project_id
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name                     = var.subnet_name
+  ip_cidr_range            = var.subnet_cidr
+  region                   = var.region
+  network                  = google_compute_network.vpc.id
+  project                  = var.project_id
+  private_ip_google_access = true
+}
+
+resource "google_vpc_access_connector" "connector" {
+  name          = var.connector_name
+  region        = var.region
+  network       = google_compute_network.vpc.name
+  ip_cidr_range = var.connector_cidr
+  min_instances = 2
+  max_instances = 3
+  machine_type  = "e2-micro"
+  project       = var.project_id
+}
+
+# IAP SSH for compute instances tagged "iap-ssh" (matches LookseeIaC pattern,
+# kept available for future debug VMs even though browser-service deploys no VMs).
+resource "google_compute_firewall" "ssh_iap" {
+  name    = "${var.vpc_name}-allow-iap-ssh"
+  network = google_compute_network.vpc.name
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = ["iap-ssh"]
+}
+
+# Reserve a private IP range for service networking (used by Cloud SQL private IP).
+resource "google_compute_global_address" "private_ip_range" {
+  name          = "${var.vpc_name}-private-ip-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.vpc.id
+  project       = var.project_id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = google_compute_network.vpc.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_range.name]
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,29 @@
+output "network_id" {
+  description = "Self-link / id of the VPC network."
+  value       = google_compute_network.vpc.id
+}
+
+output "network_name" {
+  description = "Name of the VPC network."
+  value       = google_compute_network.vpc.name
+}
+
+output "subnet_id" {
+  description = "Self-link / id of the primary subnet."
+  value       = google_compute_subnetwork.subnet.id
+}
+
+output "vpc_connector_id" {
+  description = "Self-link of the Serverless VPC Access connector."
+  value       = google_vpc_access_connector.connector.id
+}
+
+output "vpc_connector_name" {
+  description = "Short name of the Serverless VPC Access connector (used in Cloud Run annotations)."
+  value       = google_vpc_access_connector.connector.name
+}
+
+output "private_vpc_connection" {
+  description = "Service networking connection (used as a depends_on target for Cloud SQL private IP)."
+  value       = google_service_networking_connection.private_vpc_connection.id
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -25,9 +25,14 @@ variable "subnet_cidr" {
 }
 
 variable "connector_name" {
-  description = "Name of the Serverless VPC Access connector."
+  description = "Name of the Serverless VPC Access connector. GCP caps this at 25 chars."
   type        = string
-  default     = "browser-service-vpc-connector"
+  default     = "bs-vpc-conn"
+
+  validation {
+    condition     = length(var.connector_name) <= 25
+    error_message = "connector_name must be <= 25 characters (GCP Serverless VPC Access limit)."
+  }
 }
 
 variable "connector_cidr" {

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,37 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the subnet and VPC connector."
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "Name of the VPC network."
+  type        = string
+}
+
+variable "subnet_name" {
+  description = "Name of the primary subnet."
+  type        = string
+  default     = "browser-service-subnet"
+}
+
+variable "subnet_cidr" {
+  description = "CIDR range for the primary subnet."
+  type        = string
+}
+
+variable "connector_name" {
+  description = "Name of the Serverless VPC Access connector."
+  type        = string
+  default     = "browser-service-vpc-connector"
+}
+
+variable "connector_cidr" {
+  description = "CIDR range for the Serverless VPC Access connector (must be a /28)."
+  type        = string
+  default     = "10.8.0.0/28"
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -39,4 +39,10 @@ variable "connector_cidr" {
   description = "CIDR range for the Serverless VPC Access connector (must be a /28)."
   type        = string
   default     = "10.8.0.0/28"
+
+  validation {
+    # Must be a valid CIDR AND specifically /28 (Serverless VPC Access requirement).
+    condition     = can(cidrnetmask(var.connector_cidr)) && endswith(var.connector_cidr, "/28")
+    error_message = "connector_cidr must be a valid /28 CIDR block (e.g. 10.8.0.0/28). Serverless VPC Access connectors require exactly /28."
+  }
 }

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -35,3 +35,9 @@ variable "connector_cidr" {
   type        = string
   default     = "10.8.0.0/28"
 }
+
+variable "enable_nat" {
+  description = "Whether to provision a Cloud Router + Cloud NAT for outbound internet egress. Required when any caller (e.g. browser-service) uses vpc-access-egress=all-traffic and needs to reach public non-Google endpoints."
+  type        = bool
+  default     = true
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -40,9 +40,3 @@ variable "connector_cidr" {
   type        = string
   default     = "10.8.0.0/28"
 }
-
-variable "enable_nat" {
-  description = "Whether to provision a Cloud Router + Cloud NAT for outbound internet egress. Required when any caller (e.g. browser-service) uses vpc-access-egress=all-traffic and needs to reach public non-Google endpoints."
-  type        = bool
-  default     = true
-}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,9 +8,14 @@ output "browser_service_name" {
   value       = module.browser_service.service_name
 }
 
-output "selenium_grid_urls" {
-  description = "Selenium 4 grid URLs (each ends in /wd/hub) injected into SELENIUM_GRID_URLS on the API."
-  value       = [for s in module.selenium : s.grid_endpoint]
+output "selenium_grid_hosts" {
+  description = "Bare Selenium hostnames (no scheme/path) injected into SELENIUM_GRID_URLS on the API. The engine prepends https:// and appends /wd/hub at runtime."
+  value       = [for s in module.selenium : s.grid_host]
+}
+
+output "selenium_service_urls" {
+  description = "Full Cloud Run URLs of each Selenium replica (for debugging — not what gets fed into the API env var)."
+  value       = [for s in module.selenium : s.service_url]
 }
 
 output "selenium_service_names" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -54,7 +54,12 @@ output "postgres_password_secret" {
   value       = module.postgres.password_secret_name
 }
 
-output "runtime_service_account" {
-  description = "Service account email used by Cloud Run revisions."
-  value       = google_service_account.runtime.email
+output "api_service_account" {
+  description = "Service account email used by the browser-service API Cloud Run revision. Holds Secret Manager access for the DB password."
+  value       = google_service_account.api_runtime.email
+}
+
+output "selenium_service_account" {
+  description = "Service account email used by the Selenium Cloud Run replicas. No privileged role bindings — separate identity from the API for least privilege."
+  value       = google_service_account.selenium_runtime.email
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "browser_service_url" {
-  description = "Public URL of the browser-service API."
+  description = "URL of the browser-service API. Always reachable on the network with `ingress = all`; whether unauthenticated invocation is allowed depends on `browser_service_allow_public` and `browser_service_invoker_members`."
   value       = module.browser_service.service_url
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,55 @@
+output "browser_service_url" {
+  description = "Public URL of the browser-service API."
+  value       = module.browser_service.service_url
+}
+
+output "browser_service_name" {
+  description = "Cloud Run service name for the browser-service API."
+  value       = module.browser_service.service_name
+}
+
+output "selenium_grid_urls" {
+  description = "Selenium 4 grid URLs (each ends in /wd/hub) injected into SELENIUM_GRID_URLS on the API."
+  value       = [for s in module.selenium : s.grid_endpoint]
+}
+
+output "selenium_service_names" {
+  description = "Cloud Run service names for each Selenium replica."
+  value       = [for s in module.selenium : s.service_name]
+}
+
+output "vpc_network" {
+  description = "Name of the VPC the stack runs in."
+  value       = module.vpc.network_name
+}
+
+output "vpc_connector_name" {
+  description = "Serverless VPC Access connector name (used by both the API and Selenium replicas)."
+  value       = module.vpc.vpc_connector_name
+}
+
+output "postgres_instance" {
+  description = "Cloud SQL Postgres instance name."
+  value       = module.postgres.instance_name
+}
+
+output "postgres_connection_name" {
+  description = "Cloud SQL connection name (project:region:instance) for the Auth Proxy."
+  value       = module.postgres.connection_name
+}
+
+output "postgres_private_ip" {
+  description = "Private IP of the Postgres instance (only reachable from inside the VPC)."
+  value       = module.postgres.private_ip_address
+  sensitive   = true
+}
+
+output "postgres_password_secret" {
+  description = "Secret Manager secret holding the generated DB password."
+  value       = module.postgres.password_secret_name
+}
+
+output "runtime_service_account" {
+  description = "Service account email used by Cloud Run revisions."
+  value       = google_service_account.runtime.email
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  project     = var.project_id
+  region      = var.region
+  credentials = var.credentials_file != null ? file(var.credentials_file) : null
+}
+
+provider "google-beta" {
+  project     = var.project_id
+  region      = var.region
+  credentials = var.credentials_file != null ? file(var.credentials_file) : null
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,29 @@
+# Copy to terraform.tfvars and fill in. Never commit terraform.tfvars.
+
+# --- Required ---
+project_id = "your-gcp-project-id"
+
+# --- Common overrides ---
+region      = "us-central1"
+environment = "dev"
+
+# Container image for the Spring Boot API. Build + push your own image and
+# point this at it (Artifact Registry / GHCR / Docker Hub all work).
+browser_service_image = "ghcr.io/brandonkindred/browser-service:latest"
+
+# Spin up 10 Selenium Cloud Run replicas (the default).
+selenium_instance_count    = 10
+selenium_image             = "selenium/standalone-chrome:4.27.0"
+selenium_memory_allocation = "2Gi"
+selenium_cpu_allocation    = "2"
+
+# Cloud SQL Postgres sizing.
+postgres_tier         = "db-custom-1-3840"
+postgres_disk_size_gb = 20
+
+# Set false in non-prod environments so `terraform destroy` actually works.
+postgres_deletion_protection = false
+
+labels = {
+  owner = "platform"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,8 +19,13 @@ variable "environment" {
   default     = "dev"
 
   validation {
-    condition     = can(regex("^[a-z][a-z0-9-]{0,11}$", var.environment))
-    error_message = "environment must be 1-12 chars, lowercase letters/digits/hyphens, starting with a letter. The cap keeps composed names under VPC connector (25), service account (30), and Cloud Run service (49) limits."
+    # 1 char OR 2-12 chars starting with a letter and ending with an
+    # alphanumeric. The trailing-alnum requirement matters because composed
+    # names like `bs-api-${env}` and `bs-conn-${env}` get fed to GCP APIs
+    # that enforce RFC1035 (must end alphanumeric), so e.g. `dev-` would
+    # plan-pass but apply-fail.
+    condition     = can(regex("^[a-z]([a-z0-9-]{0,10}[a-z0-9])?$", var.environment))
+    error_message = "environment must be 1-12 chars: lowercase letters/digits/hyphens, starting with a letter and ending with a letter or digit (no trailing hyphen). The cap keeps composed names under VPC connector (25), service account (30), and Cloud Run service (49) limits."
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,7 @@ variable "subnet_name" {
 }
 
 variable "vpc_connector_name" {
-  description = "Name of the Serverless VPC Access connector. Defaults to 'browser-service-conn-<environment>'."
+  description = "Name of the Serverless VPC Access connector. Defaults to 'bs-conn-<environment>' (kept short to fit GCP's 25-char limit)."
   type        = string
   default     = null
 }
@@ -67,6 +67,11 @@ variable "subnet_cidr" {
   description = "Primary subnet CIDR range used by the VPC."
   type        = string
   default     = "10.10.0.0/20"
+
+  validation {
+    condition     = can(cidrnetmask(var.subnet_cidr))
+    error_message = "subnet_cidr must be a valid CIDR block (e.g. 10.10.0.0/20)."
+  }
 }
 
 #########################
@@ -80,15 +85,25 @@ variable "browser_service_image" {
 }
 
 variable "browser_service_service_name" {
-  description = "Cloud Run service name for the browser-service API."
+  description = "Cloud Run service name for the browser-service API. Composed name is `${var}-${environment}` and must fit Cloud Run's 49-char limit; with environment capped at 12 chars, this base is capped at 36."
   type        = string
   default     = "browser-service-api"
+
+  validation {
+    condition     = can(regex("^[a-z]([a-z0-9-]{0,34}[a-z0-9])?$", var.browser_service_service_name))
+    error_message = "browser_service_service_name must be 1-36 chars: lowercase letters/digits/hyphens, starting with a letter and ending with a letter or digit."
+  }
 }
 
 variable "browser_service_min_instances" {
   description = "Minimum number of browser-service Cloud Run instances kept warm."
   type        = number
   default     = 1
+
+  validation {
+    condition     = var.browser_service_min_instances >= 0 && floor(var.browser_service_min_instances) == var.browser_service_min_instances
+    error_message = "browser_service_min_instances must be a non-negative integer."
+  }
 }
 
 variable "browser_service_max_instances" {
@@ -115,9 +130,15 @@ variable "browser_service_cpu" {
 }
 
 variable "browser_service_allow_public" {
-  description = "If true, the browser-service API is invokable by allUsers. Set false to restrict to authenticated callers only."
+  description = "If true, the browser-service API is invokable by allUsers. Set false to restrict to authenticated callers only — pair with `browser_service_invoker_members` to grant specific principals, otherwise the service has no IAM bindings and is unreachable."
   type        = bool
   default     = true
+}
+
+variable "browser_service_invoker_members" {
+  description = "IAM principals granted roles/run.invoker on the browser-service API. Useful when `browser_service_allow_public = false` to grant specific service accounts or groups (e.g. ['serviceAccount:...', 'group:...']). Defaults to empty; combined with allow_public=false this means no IAM bindings and the API is unreachable until you set this."
+  type        = list(string)
+  default     = []
 }
 
 #########################
@@ -131,13 +152,13 @@ variable "selenium_image" {
 }
 
 variable "selenium_instance_count" {
-  description = "Number of Selenium standalone-chrome Cloud Run instances to provision. Must be at least 1 — the API needs at least one Selenium endpoint to open sessions."
+  description = "Number of Selenium standalone-chrome Cloud Run instances to provision. Must be a positive integer — the API needs at least one Selenium endpoint to open sessions, and module count rejects fractional values."
   type        = number
   default     = 10
 
   validation {
-    condition     = var.selenium_instance_count >= 1
-    error_message = "selenium_instance_count must be at least 1 (the API needs at least one Selenium endpoint)."
+    condition     = var.selenium_instance_count >= 1 && floor(var.selenium_instance_count) == var.selenium_instance_count
+    error_message = "selenium_instance_count must be a positive integer (>= 1)."
   }
 }
 
@@ -145,6 +166,11 @@ variable "selenium_min_instances" {
   description = "Per-replica minimum warm Cloud Run instances. Selenium standalone benefits from 1 because cold starts include Chrome boot; drop to 0 in dev to save cost."
   type        = number
   default     = 1
+
+  validation {
+    condition     = var.selenium_min_instances >= 0 && floor(var.selenium_min_instances) == var.selenium_min_instances
+    error_message = "selenium_min_instances must be a non-negative integer."
+  }
 }
 
 variable "selenium_max_instances" {
@@ -174,6 +200,11 @@ variable "selenium_port" {
   description = "Container port that Selenium standalone-chrome listens on."
   type        = number
   default     = 4444
+
+  validation {
+    condition     = var.selenium_port >= 1 && var.selenium_port <= 65535 && floor(var.selenium_port) == var.selenium_port
+    error_message = "selenium_port must be an integer in the range 1-65535."
+  }
 }
 
 variable "selenium_invoker_members" {
@@ -202,18 +233,33 @@ variable "postgres_database_name" {
   description = "Name of the application database."
   type        = string
   default     = "browser_service"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9_]{0,62}$", var.postgres_database_name))
+    error_message = "postgres_database_name must be 1-63 chars: letters/digits/underscore, starting with a letter."
+  }
 }
 
 variable "postgres_user" {
   description = "Application database user."
   type        = string
   default     = "browser_service"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9_]{0,62}$", var.postgres_user))
+    error_message = "postgres_user must be 1-63 chars: letters/digits/underscore, starting with a letter."
+  }
 }
 
 variable "postgres_disk_size_gb" {
-  description = "Disk size (GB) for the Cloud SQL instance."
+  description = "Disk size (GB) for the Cloud SQL instance. Cloud SQL minimum is 10GB."
   type        = number
   default     = 20
+
+  validation {
+    condition     = var.postgres_disk_size_gb >= 10 && floor(var.postgres_disk_size_gb) == var.postgres_disk_size_gb
+    error_message = "postgres_disk_size_gb must be an integer >= 10 (Cloud SQL minimum)."
+  }
 }
 
 variable "postgres_deletion_protection" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -112,6 +112,11 @@ variable "browser_service_max_instances" {
   default     = 10
 
   validation {
+    condition     = var.browser_service_max_instances >= 1 && floor(var.browser_service_max_instances) == var.browser_service_max_instances
+    error_message = "browser_service_max_instances must be a positive integer."
+  }
+
+  validation {
     condition     = var.browser_service_max_instances >= var.browser_service_min_instances
     error_message = "browser_service_max_instances must be >= browser_service_min_instances."
   }
@@ -177,6 +182,11 @@ variable "selenium_max_instances" {
   description = "Per-replica max Cloud Run instance count. Selenium standalone serves a single session per container, so keep this low (1 by default)."
   type        = number
   default     = 1
+
+  validation {
+    condition     = var.selenium_max_instances >= 1 && floor(var.selenium_max_instances) == var.selenium_max_instances
+    error_message = "selenium_max_instances must be a positive integer."
+  }
 
   validation {
     condition     = var.selenium_max_instances >= var.selenium_min_instances

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -74,6 +74,17 @@ variable "subnet_cidr" {
   }
 }
 
+variable "connector_cidr" {
+  description = "CIDR range for the Serverless VPC Access connector subnet (must be /28 — Serverless VPC Access requirement). Override if it overlaps with a custom `subnet_cidr`."
+  type        = string
+  default     = "10.8.0.0/28"
+
+  validation {
+    condition     = can(cidrnetmask(var.connector_cidr)) && endswith(var.connector_cidr, "/28")
+    error_message = "connector_cidr must be a valid /28 CIDR block (e.g. 10.8.0.0/28)."
+  }
+}
+
 #########################
 # Browser Service (Spring Boot API)
 #########################

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -96,6 +96,11 @@ variable "browser_service_max_instances" {
   description = "Maximum browser-service Cloud Run instance count."
   type        = number
   default     = 10
+
+  validation {
+    condition     = var.browser_service_max_instances >= var.browser_service_min_instances
+    error_message = "browser_service_max_instances must be >= browser_service_min_instances."
+  }
 }
 
 variable "browser_service_memory" {
@@ -147,6 +152,11 @@ variable "selenium_max_instances" {
   description = "Per-replica max Cloud Run instance count. Selenium standalone serves a single session per container, so keep this low (1 by default)."
   type        = number
   default     = 1
+
+  validation {
+    condition     = var.selenium_max_instances >= var.selenium_min_instances
+    error_message = "selenium_max_instances must be >= selenium_min_instances."
+  }
 }
 
 variable "selenium_memory_allocation" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,168 @@
+#########################
+# GCP project / auth
+#########################
+
+variable "project_id" {
+  description = "The GCP project ID where infrastructure will be created."
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region used for regional resources (Cloud Run, VPC connector, Cloud SQL)."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "environment" {
+  description = "Deployment environment label (dev, staging, prod). Used in resource naming and labels."
+  type        = string
+  default     = "dev"
+}
+
+variable "credentials_file" {
+  description = "Optional path to a GCP service account credentials JSON file. Leave null to use Application Default Credentials (recommended)."
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all labeled resources."
+  type        = map(string)
+  default     = {}
+}
+
+#########################
+# VPC
+#########################
+
+variable "vpc_name" {
+  description = "Name of the VPC network to create."
+  type        = string
+  default     = "browser-service-vpc"
+}
+
+variable "subnet_cidr" {
+  description = "Primary subnet CIDR range used by the VPC."
+  type        = string
+  default     = "10.10.0.0/20"
+}
+
+#########################
+# Browser Service (Spring Boot API)
+#########################
+
+variable "browser_service_image" {
+  description = "Container image for the browser-service Spring Boot API."
+  type        = string
+  default     = "ghcr.io/brandonkindred/browser-service:latest"
+}
+
+variable "browser_service_service_name" {
+  description = "Cloud Run service name for the browser-service API."
+  type        = string
+  default     = "browser-service-api"
+}
+
+variable "browser_service_min_instances" {
+  description = "Minimum number of browser-service Cloud Run instances kept warm."
+  type        = number
+  default     = 1
+}
+
+variable "browser_service_max_instances" {
+  description = "Maximum browser-service Cloud Run instance count."
+  type        = number
+  default     = 10
+}
+
+variable "browser_service_memory" {
+  description = "Memory limit for the browser-service container (e.g. 1Gi, 2Gi)."
+  type        = string
+  default     = "2Gi"
+}
+
+variable "browser_service_cpu" {
+  description = "CPU limit for the browser-service container (e.g. 1, 2)."
+  type        = string
+  default     = "2"
+}
+
+variable "browser_service_allow_public" {
+  description = "If true, the browser-service API is invokable by allUsers. Set false to restrict to authenticated callers only."
+  type        = bool
+  default     = true
+}
+
+#########################
+# Selenium (Cloud Run, fan-out)
+#########################
+
+variable "selenium_image" {
+  description = "Selenium standalone Chrome image. Mirrors the LookseeIaC selenium module pattern."
+  type        = string
+  default     = "selenium/standalone-chrome:4.27.0"
+}
+
+variable "selenium_instance_count" {
+  description = "Number of Selenium standalone-chrome Cloud Run instances to provision."
+  type        = number
+  default     = 10
+}
+
+variable "selenium_memory_allocation" {
+  description = "Memory limit for each Selenium Cloud Run container."
+  type        = string
+  default     = "2Gi"
+}
+
+variable "selenium_cpu_allocation" {
+  description = "CPU limit for each Selenium Cloud Run container."
+  type        = string
+  default     = "2"
+}
+
+variable "selenium_port" {
+  description = "Container port that Selenium standalone-chrome listens on."
+  type        = number
+  default     = 4444
+}
+
+#########################
+# Cloud SQL Postgres
+#########################
+
+variable "postgres_tier" {
+  description = "Cloud SQL machine tier (e.g. db-custom-1-3840, db-f1-micro)."
+  type        = string
+  default     = "db-custom-1-3840"
+}
+
+variable "postgres_version" {
+  description = "Cloud SQL Postgres engine version."
+  type        = string
+  default     = "POSTGRES_17"
+}
+
+variable "postgres_database_name" {
+  description = "Name of the application database."
+  type        = string
+  default     = "browser_service"
+}
+
+variable "postgres_user" {
+  description = "Application database user."
+  type        = string
+  default     = "browser_service"
+}
+
+variable "postgres_disk_size_gb" {
+  description = "Disk size (GB) for the Cloud SQL instance."
+  type        = number
+  default     = 20
+}
+
+variable "postgres_deletion_protection" {
+  description = "Whether Cloud SQL deletion protection is enabled. Keep on for prod."
+  type        = bool
+  default     = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,9 +14,14 @@ variable "region" {
 }
 
 variable "environment" {
-  description = "Deployment environment label (dev, staging, prod). Used in resource naming and labels."
+  description = "Deployment environment label (dev, staging, prod). Used as a suffix in Cloud Run, VPC connector, and service-account names — all of which have hard length limits, so this is capped at 12 chars."
   type        = string
   default     = "dev"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,11}$", var.environment))
+    error_message = "environment must be 1-12 chars, lowercase letters/digits/hyphens, starting with a letter. The cap keeps composed names under VPC connector (25), service account (30), and Cloud Run service (49) limits."
+  }
 }
 
 variable "credentials_file" {
@@ -160,6 +165,12 @@ variable "selenium_port" {
   description = "Container port that Selenium standalone-chrome listens on."
   type        = number
   default     = 4444
+}
+
+variable "selenium_invoker_members" {
+  description = "IAM principals granted roles/run.invoker on each Selenium Cloud Run replica. Defaults to 'allUsers' so the Java client (which doesn't speak GCP id-token auth) can reach the services over the VPC; ingress=internal still keeps the public internet out. Set to [] or to specific service accounts in orgs that block allUsers via iam.allowedPolicyMemberDomains."
+  type        = list(string)
+  default     = ["allUsers"]
 }
 
 #########################

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,15 +36,33 @@ variable "labels" {
 #########################
 
 variable "vpc_name" {
-  description = "Name of the VPC network to create."
+  description = "Name of the VPC network to create. Defaults to 'browser-service-vpc-<environment>' so multiple environments in the same project don't collide."
   type        = string
-  default     = "browser-service-vpc"
+  default     = null
+}
+
+variable "subnet_name" {
+  description = "Name of the primary subnet. Defaults to 'browser-service-subnet-<environment>'."
+  type        = string
+  default     = null
+}
+
+variable "vpc_connector_name" {
+  description = "Name of the Serverless VPC Access connector. Defaults to 'browser-service-conn-<environment>'."
+  type        = string
+  default     = null
 }
 
 variable "subnet_cidr" {
   description = "Primary subnet CIDR range used by the VPC."
   type        = string
   default     = "10.10.0.0/20"
+}
+
+variable "vpc_enable_nat" {
+  description = "Provision a Cloud Router + Cloud NAT so traffic exiting the VPC connector (egress=all-traffic) can reach public non-Google endpoints. Set false in environments that don't need external egress."
+  type        = bool
+  default     = true
 }
 
 #########################
@@ -104,9 +122,26 @@ variable "selenium_image" {
 }
 
 variable "selenium_instance_count" {
-  description = "Number of Selenium standalone-chrome Cloud Run instances to provision."
+  description = "Number of Selenium standalone-chrome Cloud Run instances to provision. Must be at least 1 — the API needs at least one Selenium endpoint to open sessions."
   type        = number
   default     = 10
+
+  validation {
+    condition     = var.selenium_instance_count >= 1
+    error_message = "selenium_instance_count must be at least 1 (the API needs at least one Selenium endpoint)."
+  }
+}
+
+variable "selenium_min_instances" {
+  description = "Per-replica minimum warm Cloud Run instances. Selenium standalone benefits from 1 because cold starts include Chrome boot; drop to 0 in dev to save cost."
+  type        = number
+  default     = 1
+}
+
+variable "selenium_max_instances" {
+  description = "Per-replica max Cloud Run instance count. Selenium standalone serves a single session per container, so keep this low (1 by default)."
+  type        = number
+  default     = 1
 }
 
 variable "selenium_memory_allocation" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,12 +69,6 @@ variable "subnet_cidr" {
   default     = "10.10.0.0/20"
 }
 
-variable "vpc_enable_nat" {
-  description = "Provision a Cloud Router + Cloud NAT so traffic exiting the VPC connector (egress=all-traffic) can reach public non-Google endpoints. Set false in environments that don't need external egress."
-  type        = bool
-  default     = true
-}
-
 #########################
 # Browser Service (Spring Boot API)
 #########################

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.5.0"
+      version = ">= 3.5.0, < 4.0.0"
     }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,7 @@
 terraform {
-  required_version = ">= 1.5.0"
+  # 1.9.0 adds cross-variable references in `validation` blocks, used in
+  # variables.tf to enforce min_instances <= max_instances at plan time.
+  required_version = ">= 1.9.0"
 
   required_providers {
     google = {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0, < 7.0.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 5.0.0, < 7.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained Terraform module under `terraform/` that provisions the full browser-service stack on GCP with one `terraform apply`:

- **VPC** — network, subnet, Serverless VPC Access connector, IAP-SSH firewall, and private services access for Cloud SQL.
- **Cloud SQL Postgres** — private-IP-only instance, app database + user, generated password stored in **Secret Manager** and granted to the runtime SA.
- **Selenium fleet** — `selenium_instance_count` (default **10**) Cloud Run replicas of `selenium/standalone-chrome:4.27.0`, modeled directly on [`LookseeIaC/GCP/modules/selenium`](https://github.com/brandonkindred/LookseeIaC/tree/main/GCP/modules/selenium). Each runs with `ingress = internal` + `allUsers` invoker so the Java client can reach them over the VPC without GCP id tokens.
- **browser-service API** — Cloud Run service for the Spring Boot app, wired to Postgres (`DATABASE_URL` / `DATABASE_USERNAME` / `DATABASE_PASSWORD`) and to every Selenium replica via comma-joined `SELENIUM_GRID_URLS`. Egress is `all-traffic` so internal-ingress Selenium calls traverse the VPC.

```
terraform/
├── main.tf, variables.tf, outputs.tf, providers.tf, versions.tf
├── terraform.tfvars.example
├── README.md                       # layout, IAM prereqs, cost notes, MVP gaps
└── modules/
    ├── vpc/
    ├── postgres/
    ├── selenium/                   # mirrors LookseeIaC/GCP/modules/selenium
    └── browser_service/
```

## Usage

```bash
cd terraform
cp terraform.tfvars.example terraform.tfvars   # set project_id, image, etc.
terraform init && terraform apply
```

Outputs include `browser_service_url`, `selenium_grid_urls`, the Cloud SQL connection name, and the Secret Manager secret name for the DB password.

## Test plan

- [ ] `terraform fmt -recursive terraform/` is clean
- [ ] `terraform init` succeeds in `terraform/`
- [ ] `terraform validate` passes
- [ ] `terraform plan` against a real GCP project shows the expected resources (VPC + Postgres + 10 Selenium services + 1 API service)
- [ ] Smoke test after `apply`: `curl $(terraform output -raw browser_service_url)/v1/sessions -d '{"browser":"chrome","environment":"discovery"}'` returns a session ID

## Out of scope (matches the service's MVP)

- No auth on the API (`browser_service_allow_public = true` by default).
- No Cloud Armor / load balancer in front of Cloud Run.
- No CI step that builds + pushes the API image; point `browser_service_image` at a pre-published one.
- No remote state backend; configure GCS in `versions.tf` for shared envs.

https://claude.ai/code/session_01K63fwh7bVCUu8283grCeYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01K63fwh7bVCUu8283grCeYp)_