### PR TITLE
[Caller-Id 5/5] Surface owner in DTOs, reaper log, and docs (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,39 +36,57 @@ The HTTP surface below is the asynchronous side of the API. The real-time socket
 ```bash
 # 1. Open a session.
 curl -X POST http://browser-service/v1/sessions \
+  -H 'X-Caller-Id: alice' \
   -H 'Content-Type: application/json' \
   -d '{"browser": "chrome", "environment": "discovery"}'
-# -> {"session_id": "abc123", "expires_at": "2026-04-22T18:35:00Z", ...}
+# -> {"session_id": "abc123", "owner_id": "alice", "expires_at": "2026-04-22T18:35:00Z", ...}
 
 # 2. Navigate.
 curl -X POST http://browser-service/v1/sessions/abc123/navigate \
+  -H 'X-Caller-Id: alice' \
   -H 'Content-Type: application/json' \
   -d '{"url": "https://example.com"}'
 
 # 3. Find an element.
 curl -X POST http://browser-service/v1/sessions/abc123/element/find \
+  -H 'X-Caller-Id: alice' \
   -H 'Content-Type: application/json' \
   -d '{"xpath": "//button[@id=\"submit\"]"}'
 # -> {"element_handle": "el_42", "found": true, "displayed": true, ...}
 
 # 4. Click it.
 curl -X POST http://browser-service/v1/sessions/abc123/element/action \
+  -H 'X-Caller-Id: alice' \
   -H 'Content-Type: application/json' \
   -d '{"element_handle": "el_42", "action": "click"}'
 
 # 5. Screenshot (bytes).
 curl -X POST http://browser-service/v1/sessions/abc123/screenshot \
+  -H 'X-Caller-Id: alice' \
   -H 'Content-Type: application/json' \
   -d '{"strategy": "full_page_shutterbug"}' \
   --output page.png
 
 # 6. Close. Frees the browser and counts against the caller's 10-session cap.
-curl -X DELETE http://browser-service/v1/sessions/abc123
+curl -X DELETE http://browser-service/v1/sessions/abc123 \
+  -H 'X-Caller-Id: alice'
 ```
 
 Idle sessions expire after 5 minutes; all sessions expire after 30 minutes, no matter what. The registry reaps them automatically. Operations against a `session_id` that has been reaped return a `session_expired` error so the caller can react instead of silently retrying on a fresh browser.
 
 For the trivial "open → navigate → screenshot → close" path, `POST /v1/capture` collapses all of the above into one request.
+
+## Caller identity
+
+Every request under `/v1/` must carry an `X-Caller-Id` header. The value is printable ASCII (`0x21`–`0x7E`), 1–128 chars, no internal whitespace — UUIDs, e-mails, and Kubernetes service-account names all pass. The service does not authenticate it; it is the sole identifier used for ownership and per-caller isolation.
+
+- **Missing or blank header** → `400 caller_unidentified`.
+- **Wrong owner** for an existing session → `403 session_forbidden`.
+- `GET /v1/sessions` returns only the calling caller's sessions; one caller cannot see, describe, drive, or close another caller's sessions.
+- The 10-concurrent-session cap is keyed off this header, as is the `owner_id` field returned in `SessionResponse` / `SessionStateResponse`.
+- Health probes (`/healthz`, `/readyz`) do not require the header.
+
+Authentication of the header value (mTLS, signed identity, etc.) is deferred — see [Explicitly out of MVP](#explicitly-out-of-mvp).
 
 ## MVP scope
 
@@ -89,7 +107,7 @@ For the trivial "open → navigate → screenshot → close" path, `POST /v1/cap
 
 Listed here so nothing gets forgotten:
 
-- **Authentication.** Service runs on a private network (VPC-only ingress). API keys / OAuth / per-tenant isolation deferred. The 10-sessions-per-caller cap is keyed off whatever caller identity the network layer surfaces (source IP, header) until proper auth lands.
+- **Authentication.** Service runs on a private network (VPC-only ingress). API keys / OAuth / per-tenant isolation deferred. The required `X-Caller-Id` header is treated as trusted attribution (not authn) until proper auth lands; the 10-sessions-per-caller cap is keyed off it.
 - **Rate limits / quotas beyond the per-caller session cap.** Need auth first to key off properly.
 - **Network egress policy.** SSRF guard against `localhost` / `169.254.169.254` / private CIDRs — defer to post-auth.
 - **Push events on the socket beyond operation results.** The real-time socket carries operation results in this phase. Page-load progress, console logs, network events, DOM mutations come later if a caller asks.

--- a/api/src/main/java/io/browserservice/api/dto/SessionResponse.java
+++ b/api/src/main/java/io/browserservice/api/dto/SessionResponse.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 @Schema(description = "Summary of an active browser session.")
 public record SessionResponse(
     @Schema(description = "Session identifier") UUID sessionId,
+    @Schema(description = "Caller that owns the session (`X-Caller-Id` of the creator)")
+        String ownerId,
     @Schema(description = "Browser type") BrowserType browserType,
     @Schema(description = "Session environment") BrowserEnvironment environment,
     @Schema(description = "Instant the session was created") Instant createdAt,

--- a/api/src/main/java/io/browserservice/api/dto/SessionStateResponse.java
+++ b/api/src/main/java/io/browserservice/api/dto/SessionStateResponse.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 @Schema(description = "Session state snapshot including current URL, viewport, and scroll offset.")
 public record SessionStateResponse(
     @Schema(description = "Session identifier") UUID sessionId,
+    @Schema(description = "Caller that owns the session (`X-Caller-Id` of the creator)")
+        String ownerId,
     @Schema(description = "Browser type") BrowserType browserType,
     @Schema(description = "Session environment") BrowserEnvironment environment,
     @Schema(description = "Instant the session was created") Instant createdAt,

--- a/api/src/main/java/io/browserservice/api/service/SessionService.java
+++ b/api/src/main/java/io/browserservice/api/service/SessionService.java
@@ -127,6 +127,7 @@ public class SessionService {
     ScrollOffset scrollOffset = safeScrollOffset(handle);
     return new SessionStateResponse(
         handle.id(),
+        handle.owner().value(),
         handle.browserType(),
         handle.environment(),
         handle.createdAt(),
@@ -139,6 +140,7 @@ public class SessionService {
   private static SessionResponse toSummary(SessionHandle handle) {
     return new SessionResponse(
         handle.id(),
+        handle.owner().value(),
         handle.browserType(),
         handle.environment(),
         handle.createdAt(),

--- a/api/src/main/java/io/browserservice/api/session/SessionReaper.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionReaper.java
@@ -32,8 +32,9 @@ public class SessionReaper {
       if (registry.remove(handle.id())) {
         tracker.recordReap(handle.id(), reason);
         log.info(
-            "reaped session id={} browserType={} reason={} idleTtl={}s absoluteTtl={}s",
+            "reaped session id={} owner={} browserType={} reason={} idleTtl={}s absoluteTtl={}s",
             handle.id(),
+            handle.owner().value(),
             handle.browserType(),
             reason,
             handle.idleTtl().toSeconds(),

--- a/api/src/test/java/io/browserservice/api/controller/ControllerHttpTest.java
+++ b/api/src/test/java/io/browserservice/api/controller/ControllerHttpTest.java
@@ -161,6 +161,7 @@ class ControllerHttpTest {
         .thenReturn(
             new SessionResponse(
                 id,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -175,7 +176,8 @@ class ControllerHttpTest {
                         new CreateSessionRequest(
                             BrowserType.CHROME, BrowserEnvironment.TEST, null))))
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.session_id").value(id.toString()));
+        .andExpect(jsonPath("$.session_id").value(id.toString()))
+        .andExpect(jsonPath("$.owner_id").value("alice"));
   }
 
   @Test
@@ -236,6 +238,7 @@ class ControllerHttpTest {
         .thenReturn(
             new SessionStateResponse(
                 id,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -246,7 +249,8 @@ class ControllerHttpTest {
 
     mvc.perform(get("/v1/sessions/" + id).header("X-Caller-Id", "alice"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.current_url").value("https://x"));
+        .andExpect(jsonPath("$.current_url").value("https://x"))
+        .andExpect(jsonPath("$.owner_id").value("alice"));
   }
 
   @Test
@@ -309,6 +313,7 @@ class ControllerHttpTest {
                     List.of(
                         new SessionResponse(
                             aliceSession,
+                            "alice",
                             BrowserType.CHROME,
                             BrowserEnvironment.TEST,
                             Instant.now(),

--- a/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
+++ b/api/src/test/java/io/browserservice/api/service/SessionServiceTest.java
@@ -65,6 +65,7 @@ class SessionServiceTest {
     assertThat(response.browserType()).isEqualTo(BrowserType.CHROME);
     assertThat(response.environment()).isEqualTo(BrowserEnvironment.TEST);
     assertThat(response.sessionId()).isNotNull();
+    assertThat(response.ownerId()).isEqualTo("alice");
     assertThat(registry.size()).isEqualTo(1);
   }
 
@@ -170,8 +171,14 @@ class SessionServiceTest {
     service.create(
         new CreateSessionRequest(BrowserType.CHROME, BrowserEnvironment.TEST, null), BOB);
 
-    assertThat(service.list(ALICE).sessions()).hasSize(1);
-    assertThat(service.list(BOB).sessions()).hasSize(1);
+    assertThat(service.list(ALICE).sessions())
+        .singleElement()
+        .extracting(SessionResponse::ownerId)
+        .isEqualTo("alice");
+    assertThat(service.list(BOB).sessions())
+        .singleElement()
+        .extracting(SessionResponse::ownerId)
+        .isEqualTo("bob");
     assertThat(service.list(CallerId.parse("eve")).sessions()).isEmpty();
   }
 
@@ -187,6 +194,7 @@ class SessionServiceTest {
     SessionStateResponse state = service.describe(created.sessionId(), ALICE);
 
     assertThat(state.sessionId()).isEqualTo(created.sessionId());
+    assertThat(state.ownerId()).isEqualTo("alice");
     assertThat(state.viewport()).isNotNull();
     assertThat(state.scrollOffset().x()).isEqualTo(10);
     assertThat(state.scrollOffset().y()).isEqualTo(20);

--- a/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
+++ b/api/src/test/java/io/browserservice/api/session/SessionReaperTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.looksee.browser.Browser;
 import com.looksee.browser.enums.BrowserEnvironment;
 import com.looksee.browser.enums.BrowserType;
@@ -15,6 +18,7 @@ import io.browserservice.api.persistence.BrowserSessionTracker;
 import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 class SessionReaperTest {
 
@@ -77,6 +81,41 @@ class SessionReaperTest {
     new SessionReaper(registry, tracker).reap();
 
     verify(tracker).recordReap(absoluteExpired.id(), ClosedReason.REAPED_ABSOLUTE);
+  }
+
+  @Test
+  void reapLogLineNamesTheOwner() throws Exception {
+    SessionRegistry registry = new SessionRegistry(props());
+    BrowserSessionTracker tracker = mock(BrowserSessionTracker.class);
+    SessionHandle expired =
+        SessionHandle.desktop(
+            mock(Browser.class),
+            CallerId.parse("alice"),
+            BrowserType.CHROME,
+            BrowserEnvironment.TEST,
+            Duration.ofMillis(1),
+            Duration.ofSeconds(60));
+    registry.acquirePermit();
+    registry.register(expired);
+    Thread.sleep(10);
+
+    ch.qos.logback.classic.Logger reaperLogger =
+        (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(SessionReaper.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    reaperLogger.addAppender(appender);
+    try {
+      new SessionReaper(registry, tracker).reap();
+    } finally {
+      reaperLogger.detachAppender(appender);
+    }
+
+    assertThat(appender.list)
+        .anySatisfy(
+            event -> {
+              assertThat(event.getLevel()).isEqualTo(Level.INFO);
+              assertThat(event.getFormattedMessage()).contains("owner=alice");
+            });
   }
 
   @Test

--- a/api/src/test/java/io/browserservice/api/ws/SessionWebSocketHandlerTest.java
+++ b/api/src/test/java/io/browserservice/api/ws/SessionWebSocketHandlerTest.java
@@ -111,6 +111,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -165,6 +166,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -223,6 +225,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -258,6 +261,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -292,6 +296,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -328,6 +333,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -336,6 +342,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionStateResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -370,6 +377,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 first,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -377,6 +385,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 second,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -418,6 +427,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 UUID.randomUUID(),
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -460,6 +470,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -498,6 +509,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -531,6 +543,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -577,6 +590,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -621,6 +635,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -665,6 +680,7 @@ class SessionWebSocketHandlerTest {
         .thenReturn(
             new SessionResponse(
                 sid,
+                "alice",
                 BrowserType.CHROME,
                 BrowserEnvironment.TEST,
                 Instant.now(),
@@ -692,6 +708,7 @@ class SessionWebSocketHandlerTest {
           .thenReturn(
               new SessionStateResponse(
                   sid,
+                  "alice",
                   BrowserType.CHROME,
                   BrowserEnvironment.TEST,
                   Instant.now(),

--- a/docs/design/openapi-draft-v1.yaml
+++ b/docs/design/openapi-draft-v1.yaml
@@ -37,6 +37,26 @@ info:
     returns 429 once the cap is reached, until one is closed (either
     explicitly by the caller or by the idle timeout).
 
+    ## Caller identity
+
+    Every operation under `/v1/` requires an `X-Caller-Id` header. The value
+    must be printable ASCII (`0x21`–`0x7E`), no internal whitespace, and at
+    most 128 characters — UUIDs, e-mails, and Kubernetes service-account
+    names all pass. The header is the sole identifier for ownership and
+    isolation; this service does not authenticate it.
+
+    - Missing or blank header → `400 caller_unidentified`.
+    - A request against a session owned by a different caller →
+      `403 session_forbidden`.
+    - `GET /sessions` returns only the calling caller's sessions; one
+      caller cannot see, describe, drive, or close another caller's
+      sessions.
+    - Health probes (`/healthz`, `/readyz`) do not require the header.
+
+    Responses surface the binding via an `owner_id` field on `Session` and
+    `SessionState` so operators can answer "whose session is this?" without
+    correlating against memory state.
+
     ## Not in MVP
 
     - Authentication (service runs on a private network)
@@ -82,6 +102,8 @@ tags:
 
 paths:
   /sessions:
+    parameters:
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Sessions]
       summary: Create a new browser session
@@ -128,6 +150,7 @@ paths:
   /sessions/{id}:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     get:
       tags: [Sessions]
       summary: Get session state
@@ -151,6 +174,7 @@ paths:
   /sessions/{id}/navigate:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Navigation]
       summary: Navigate to a URL
@@ -180,6 +204,7 @@ paths:
   /sessions/{id}/source:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     get:
       tags: [Navigation]
       summary: Get current page HTML source
@@ -196,6 +221,7 @@ paths:
   /sessions/{id}/status:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     get:
       tags: [Navigation]
       summary: Inspect page-level status
@@ -215,6 +241,7 @@ paths:
   /sessions/{id}/screenshot:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Screenshots]
       summary: Capture a screenshot
@@ -251,6 +278,7 @@ paths:
   /sessions/{id}/element/screenshot:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Screenshots]
       summary: Capture a screenshot of a single element
@@ -274,6 +302,7 @@ paths:
   /sessions/{id}/element/find:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Elements]
       summary: Find an element and return its state
@@ -304,6 +333,7 @@ paths:
   /sessions/{id}/element/action:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Elements]
       summary: Perform a desktop action on an element
@@ -329,6 +359,7 @@ paths:
   /sessions/{id}/element/touch:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Touch]
       summary: Perform a touch gesture on an element
@@ -354,6 +385,7 @@ paths:
   /sessions/{id}/scroll:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Scrolling]
       summary: Scroll the viewport
@@ -385,6 +417,7 @@ paths:
   /sessions/{id}/viewport:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     get:
       tags: [Scrolling]
       summary: Get current viewport dimensions and scroll offset
@@ -401,6 +434,7 @@ paths:
   /sessions/{id}/dom/remove:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [DOM]
       summary: Remove DOM element(s)
@@ -426,6 +460,7 @@ paths:
   /sessions/{id}/alert:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     get:
       tags: [Alerts]
       summary: Check for a native alert
@@ -442,6 +477,7 @@ paths:
   /sessions/{id}/alert/respond:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Alerts]
       summary: Accept or dismiss a native alert
@@ -462,6 +498,7 @@ paths:
   /sessions/{id}/mouse/move:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Mouse]
       summary: Move the mouse (desktop only)
@@ -487,6 +524,7 @@ paths:
   /sessions/{id}/execute:
     parameters:
       - $ref: "#/components/parameters/SessionId"
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Elements]
       summary: Execute arbitrary JavaScript (escape hatch)
@@ -512,6 +550,8 @@ paths:
         "404": { $ref: "#/components/responses/SessionNotFound" }
 
   /capture:
+    parameters:
+      - $ref: "#/components/parameters/CallerId"
     post:
       tags: [Capture]
       summary: One-shot navigate + capture + close
@@ -547,6 +587,7 @@ paths:
         in: path
         required: true
         schema: { type: string }
+      - $ref: "#/components/parameters/CallerId"
     get:
       tags: [Capture]
       summary: Fetch a one-shot capture's screenshot bytes
@@ -625,6 +666,22 @@ components:
         type: string
         minLength: 1
 
+    CallerId:
+      name: X-Caller-Id
+      in: header
+      required: true
+      description: |
+        Identifier for the caller. Printable ASCII (`0x21`–`0x7E`), no
+        internal whitespace, length 1–128. Sole basis for session
+        ownership and per-caller isolation. Missing or blank →
+        `400 caller_unidentified`; mismatch against an existing session →
+        `403 session_forbidden`.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 128
+        pattern: '^[\x21-\x7E]+$'
+
   responses:
     BadRequest:
       description: Request was malformed or failed validation
@@ -678,9 +735,12 @@ components:
 
     Session:
       type: object
-      required: [session_id, browser, environment, created_at, expires_at]
+      required: [session_id, owner_id, browser, environment, created_at, expires_at]
       properties:
         session_id: { type: string }
+        owner_id:
+          type: string
+          description: Caller that owns the session — the `X-Caller-Id` of the creator.
         browser: { $ref: "#/components/schemas/BrowserType" }
         environment: { $ref: "#/components/schemas/BrowserEnvironment" }
         created_at: { type: string, format: date-time }

--- a/openapi/generated.yaml
+++ b/openapi/generated.yaml
@@ -557,6 +557,9 @@ components:
           description: Instant at which the session will be reaped
           format: date-time
           type: string
+        ownerId:
+          description: Caller that owns the session (`X-Caller-Id` of the creator)
+          type: string
         sessionId:
           description: Session identifier
           format: uuid
@@ -592,6 +595,9 @@ components:
         expiresAt:
           description: Instant at which the session will be reaped
           format: date-time
+          type: string
+        ownerId:
+          description: Caller that owns the session (`X-Caller-Id` of the creator)
           type: string
         scrollOffset:
           $ref: '#/components/schemas/ScrollOffset'


### PR DESCRIPTION
## Summary

- Adds `ownerId` to `SessionResponse` and `SessionStateResponse`, populated from `SessionHandle.owner().value()` in `SessionService.toSummary` / `toStateLocked`.
- Includes `owner=` in the `SessionReaper` reap log line so audit can answer "whose session was just reaped" without tailing memory state.
- Documents the `X-Caller-Id` contract (required header, ASCII validation rules, 400 `caller_unidentified` / 403 `session_forbidden`, cross-caller isolation, `owner_id` in responses) in `README.md` and the design draft `docs/design/openapi-draft-v1.yaml`.
- Refreshes the committed `openapi/generated.yaml` snapshot so consumers see the new `ownerId` field on both schemas.

Closes #50, the final sub-issue of the Caller-Id rollout. Once merged, umbrella #3 closes too — broader temporal observability (reap reason, `lastUsedAt`, per-caller metrics) is owned by #4.

## Test plan

- [x] `./mvnw -pl api -am verify -DskipITs` — green (266 unit tests).
- [x] New `SessionServiceTest` assertions confirm `ownerId` is populated on `create`, `describe`, and `list` paths.
- [x] New `SessionReaperTest.reapLogLineNamesTheOwner` captures the SLF4J output via a Logback `ListAppender` and asserts the reap line contains `owner=alice`.
- [x] `ControllerHttpTest` extended with `$.owner_id` JSON-path assertions on the create + describe responses.
- [x] `SpecExportTest` re-passes against the refreshed `openapi/generated.yaml`.
- [ ] Manual smoke (post-deploy): `curl … /v1/sessions/$ID -H 'X-Caller-Id: alice' | jq .owner_id` returns `"alice"`; reap log line includes `owner=alice`.

https://claude.ai/code/session_01PCCPjjytchHZBGKNcdsELK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCCPjjytchHZBGKNcdsELK)_