### PR TITLE
fix(engine): honor configured Selenium URLs in all envs, re-enable SeleniumGridIT (#43)

### DIFF
--- a/api/src/main/java/io/browserservice/api/config/EngineProperties.java
+++ b/api/src/main/java/io/browserservice/api/config/EngineProperties.java
@@ -33,6 +33,8 @@ public record EngineProperties(
       @DefaultValue("16777216") int maxBinaryFrameBytes) {}
 
   /**
+   * Selenium hub configuration consumed by the engine for chrome/firefox driver creation.
+   *
    * @param urls comma-separated, fully qualified Selenium hub URLs including scheme and path, e.g.
    *     {@code http://host:4444/wd/hub}. The engine consumes entries verbatim and does not rewrite
    *     scheme or append path segments.
@@ -46,6 +48,8 @@ public record EngineProperties(
       @DefaultValue("10") int implicitWaitSeconds) {}
 
   /**
+   * Appium server configuration consumed by the engine for mobile driver creation.
+   *
    * @param urls comma-separated, fully qualified Appium server URLs including scheme and path, e.g.
    *     {@code http://host:4723/wd/hub}. Empty disables mobile support. The engine consumes entries
    *     verbatim and does not rewrite scheme or append path segments.

--- a/api/src/main/java/io/browserservice/api/config/EngineProperties.java
+++ b/api/src/main/java/io/browserservice/api/config/EngineProperties.java
@@ -32,6 +32,11 @@ public record EngineProperties(
       @DefaultValue("50") int watcherLockTimeoutMs,
       @DefaultValue("16777216") int maxBinaryFrameBytes) {}
 
+  /**
+   * @param urls comma-separated, fully qualified Selenium hub URLs including scheme and path, e.g.
+   *     {@code http://host:4444/wd/hub}. The engine consumes entries verbatim and does not rewrite
+   *     scheme or append path segments.
+   */
   public record SeleniumProps(
       @DefaultValue("http://localhost:4444/wd/hub") String urls,
       @DefaultValue("15000") int connectTimeoutMs,
@@ -40,6 +45,11 @@ public record EngineProperties(
       @DefaultValue("false") boolean implicitWaitEnabled,
       @DefaultValue("10") int implicitWaitSeconds) {}
 
+  /**
+   * @param urls comma-separated, fully qualified Appium server URLs including scheme and path, e.g.
+   *     {@code http://host:4723/wd/hub}. Empty disables mobile support. The engine consumes entries
+   *     verbatim and does not rewrite scheme or append path segments.
+   */
   public record AppiumProps(
       @DefaultValue("") String urls,
       @DefaultValue("ANDROID") String platform,

--- a/api/src/test/java/io/browserservice/api/integration/SeleniumGridIT.java
+++ b/api/src/test/java/io/browserservice/api/integration/SeleniumGridIT.java
@@ -56,6 +56,8 @@ class SeleniumGridIT {
 
   @Autowired private ObjectMapper json;
 
+  private static final String CALLER_ID = "selenium-grid-it";
+
   @Test
   void createNavigateScreenshotDeleteSmokeTest() throws Exception {
     CreateSessionRequest createReq =
@@ -67,6 +69,7 @@ class SeleniumGridIT {
     String createResponse =
         mvc.perform(
                 post("/v1/sessions")
+                    .header("X-Caller-Id", CALLER_ID)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(json.writeValueAsString(createReq)))
             .andExpect(status().isCreated())
@@ -80,6 +83,7 @@ class SeleniumGridIT {
     NavigateRequest navigateReq = new NavigateRequest("about:blank", null);
     mvc.perform(
             post("/v1/sessions/" + sessionId + "/navigate")
+                .header("X-Caller-Id", CALLER_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.writeValueAsString(navigateReq)))
         .andExpect(status().isOk())
@@ -88,11 +92,13 @@ class SeleniumGridIT {
     ScreenshotRequest screenshotReq = new ScreenshotRequest(ScreenshotStrategy.VIEWPORT, null);
     mvc.perform(
             post("/v1/sessions/" + sessionId + "/screenshot")
+                .header("X-Caller-Id", CALLER_ID)
                 .accept(MediaType.IMAGE_PNG)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json.writeValueAsString(screenshotReq)))
         .andExpect(status().isOk());
 
-    mvc.perform(delete("/v1/sessions/" + sessionId)).andExpect(status().isNoContent());
+    mvc.perform(delete("/v1/sessions/" + sessionId).header("X-Caller-Id", CALLER_ID))
+        .andExpect(status().isNoContent());
   }
 }

--- a/api/src/test/java/io/browserservice/api/integration/SeleniumGridIT.java
+++ b/api/src/test/java/io/browserservice/api/integration/SeleniumGridIT.java
@@ -14,7 +14,6 @@ import io.browserservice.api.dto.ScreenshotRequest;
 import io.browserservice.api.dto.ScreenshotStrategy;
 import java.time.Duration;
 import java.util.UUID;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -34,20 +33,10 @@ import org.testcontainers.utility.DockerImageName;
  *
  * <p>Requires a working Docker daemon. Skipped via surefire (included by failsafe's {@code
  * *IT.java} naming convention).
- *
- * <p><b>Currently excluded from CI</b> via the {@code requires-selenium-grid} JUnit tag, because
- * the engine's {@link com.looksee.browser.helpers.BrowserConnectionHelper#getConnection} only
- * consumes the configured Selenium URLs when {@link com.looksee.browser.enums.BrowserEnvironment}
- * is {@code DISCOVERY} — and even that branch hardcodes {@code https://}, which doesn't match
- * Testcontainers' HTTP Selenium endpoint. Re-enable once the engine accepts injected URLs
- * unconditionally; tracked in #43.
- *
- * <p>To run locally despite the tag: {@code ./mvnw -B -ntp -DexcludedGroups= verify}.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
 @org.springframework.test.context.ActiveProfiles("test")
-@Tag("requires-selenium-grid")
 @Testcontainers
 class SeleniumGridIT {
 

--- a/engine/src/main/java/com/looksee/browser/config/AppiumProperties.java
+++ b/engine/src/main/java/com/looksee/browser/config/AppiumProperties.java
@@ -17,8 +17,9 @@ import lombok.Setter;
 public class AppiumProperties {
 
   /**
-   * Comma-separated list of Appium server URLs. Example:
-   * "appium-server-1:4723,appium-server-2:4723"
+   * Comma-separated list of Appium server URLs. Each entry must be a fully qualified URL including
+   * scheme and path; values are passed verbatim to the driver. Example:
+   * "http://appium-server-1:4723/wd/hub,http://appium-server-2:4723/wd/hub"
    */
   private String urls;
 

--- a/engine/src/main/java/com/looksee/browser/helpers/BrowserConnectionHelper.java
+++ b/engine/src/main/java/com/looksee/browser/helpers/BrowserConnectionHelper.java
@@ -132,7 +132,9 @@ public class BrowserConnectionHelper {
         throw new IllegalStateException(
             "No Selenium hub URLs configured. Set browserservice.selenium.urls.");
       }
-      server_url = new URL(HUB_URLS[Math.floorMod(SELENIUM_HUB_IDX++, HUB_URLS.length)]);
+      int idx = Math.floorMod(SELENIUM_HUB_IDX, HUB_URLS.length);
+      SELENIUM_HUB_IDX++;
+      server_url = new URL(HUB_URLS[idx]);
     }
 
     return BrowserFactory.createBrowser(browser.toString(), server_url);
@@ -165,7 +167,9 @@ public class BrowserConnectionHelper {
       throw new IllegalStateException("No Appium URLs configured. Set browserservice.appium.urls.");
     }
 
-    URL server_url = new URL(APPIUM_URLS[Math.floorMod(APPIUM_SERVER_IDX++, APPIUM_URLS.length)]);
+    int idx = Math.floorMod(APPIUM_SERVER_IDX, APPIUM_URLS.length);
+    APPIUM_SERVER_IDX++;
+    URL server_url = new URL(APPIUM_URLS[idx]);
 
     return MobileFactory.createMobileDevice(browser.toString(), server_url);
   }

--- a/engine/src/main/java/com/looksee/browser/helpers/BrowserConnectionHelper.java
+++ b/engine/src/main/java/com/looksee/browser/helpers/BrowserConnectionHelper.java
@@ -47,8 +47,9 @@ public class BrowserConnectionHelper {
   private static BrowserStackProperties browserStackProperties = null;
 
   /**
-   * Gets the selenium hub URLs, either from environment variable SELENIUM_URLS or fallback to
-   * hardcoded list
+   * Sets the Selenium hub URLs used to round-robin chrome/firefox driver connections. Each entry
+   * must be a fully qualified URL including scheme and path, e.g. {@code http://host:4444/wd/hub}.
+   * No scheme or path rewriting is performed.
    *
    * @param urls the selenium hub URLs
    *     <p>precondition: urls != null
@@ -59,7 +60,9 @@ public class BrowserConnectionHelper {
   }
 
   /**
-   * Sets the Appium server URLs for mobile driver connections
+   * Sets the Appium server URLs for mobile driver connections. Each entry must be a fully qualified
+   * URL including scheme and path, e.g. {@code http://host:4723/wd/hub}. No scheme or path
+   * rewriting is performed.
    *
    * @param urls the Appium server URLs
    *     <p>precondition: urls != null
@@ -96,13 +99,19 @@ public class BrowserConnectionHelper {
   }
 
   /**
-   * Creates a {@link Browser} connection
+   * Creates a {@link Browser} connection.
+   *
+   * <p>For chrome/firefox the configured hub URLs (see {@link #setConfiguredSeleniumUrls}) are
+   * round-robined and used verbatim — entries are expected to be fully qualified, e.g. {@code
+   * http://host:4444/wd/hub}. The {@code environment} parameter is currently unused for URL
+   * selection and is reserved for future per-environment routing.
    *
    * @param browser the browser to connect to
    * @param environment the environment to connect to
    * @return the browser connection
    *     <p>precondition: browser != null precondition: environment != null
    * @throws MalformedURLException if the url is malformed
+   * @throws IllegalStateException if no Selenium hub URLs are configured for chrome/firefox
    */
   public static Browser getConnection(BrowserType browser, BrowserEnvironment environment)
       throws MalformedURLException {
@@ -117,11 +126,13 @@ public class BrowserConnectionHelper {
 
     URL server_url = null;
 
-    if (environment.equals(BrowserEnvironment.DISCOVERY)
-        && ("chrome".equalsIgnoreCase(browser.toString())
-            || "firefox".equalsIgnoreCase(browser.toString()))) {
-      server_url = new URL("https://" + HUB_URLS[SELENIUM_HUB_IDX % HUB_URLS.length] + "/wd/hub");
-      SELENIUM_HUB_IDX++;
+    if ("chrome".equalsIgnoreCase(browser.toString())
+        || "firefox".equalsIgnoreCase(browser.toString())) {
+      if (HUB_URLS == null || HUB_URLS.length == 0) {
+        throw new IllegalStateException(
+            "No Selenium hub URLs configured. Set browserservice.selenium.urls.");
+      }
+      server_url = new URL(HUB_URLS[Math.floorMod(SELENIUM_HUB_IDX++, HUB_URLS.length)]);
     }
 
     return BrowserFactory.createBrowser(browser.toString(), server_url);
@@ -151,12 +162,10 @@ public class BrowserConnectionHelper {
     }
 
     if (APPIUM_URLS == null || APPIUM_URLS.length == 0) {
-      throw new IllegalStateException("Appium URLs not configured. Set appium.urls property.");
+      throw new IllegalStateException("No Appium URLs configured. Set browserservice.appium.urls.");
     }
 
-    URL server_url =
-        new URL("http://" + APPIUM_URLS[APPIUM_SERVER_IDX % APPIUM_URLS.length] + "/wd/hub");
-    APPIUM_SERVER_IDX++;
+    URL server_url = new URL(APPIUM_URLS[Math.floorMod(APPIUM_SERVER_IDX++, APPIUM_URLS.length)]);
 
     return MobileFactory.createMobileDevice(browser.toString(), server_url);
   }

--- a/engine/src/test/java/com/looksee/browser/helpers/BrowserConnectionHelperTest.java
+++ b/engine/src/test/java/com/looksee/browser/helpers/BrowserConnectionHelperTest.java
@@ -25,13 +25,15 @@ public class BrowserConnectionHelperTest {
 
   @Test
   public void testSetConfiguredSeleniumUrls() {
-    String[] urls = {"hub1.example.com", "hub2.example.com"};
+    String[] urls = {"http://hub1.example.com:4444/wd/hub", "http://hub2.example.com:4444/wd/hub"};
     assertDoesNotThrow(() -> BrowserConnectionHelper.setConfiguredSeleniumUrls(urls));
   }
 
   @Test
   public void testSetConfiguredAppiumUrls() {
-    String[] urls = {"appium1.example.com:4723", "appium2.example.com:4723"};
+    String[] urls = {
+      "http://appium1.example.com:4723/wd/hub", "http://appium2.example.com:4723/wd/hub"
+    };
     assertDoesNotThrow(() -> BrowserConnectionHelper.setConfiguredAppiumUrls(urls));
   }
 
@@ -108,7 +110,8 @@ public class BrowserConnectionHelperTest {
 
   @Test
   public void testGetConnectionWithDiscoveryEnvironmentChrome() {
-    BrowserConnectionHelper.setConfiguredSeleniumUrls(new String[] {"localhost:4444"});
+    BrowserConnectionHelper.setConfiguredSeleniumUrls(
+        new String[] {"http://localhost:4444/wd/hub"});
     // Will fail when trying to connect to hub, but exercises the round-robin path
     assertThrows(
         Exception.class,
@@ -119,7 +122,8 @@ public class BrowserConnectionHelperTest {
 
   @Test
   public void testGetConnectionWithDiscoveryEnvironmentFirefox() {
-    BrowserConnectionHelper.setConfiguredSeleniumUrls(new String[] {"localhost:4444"});
+    BrowserConnectionHelper.setConfiguredSeleniumUrls(
+        new String[] {"http://localhost:4444/wd/hub"});
     assertThrows(
         Exception.class,
         () ->
@@ -128,12 +132,28 @@ public class BrowserConnectionHelperTest {
   }
 
   @Test
-  public void testGetConnectionWithTestEnvironment() {
-    BrowserConnectionHelper.setConfiguredSeleniumUrls(new String[] {"localhost:4444"});
-    // TEST environment with chrome won't match DISCOVERY branch, server_url remains null
-    // which triggers an assertion error in BrowserFactory.createBrowser
+  public void testGetConnectionWithTestEnvironmentChromeUsesConfiguredUrl() {
+    // Regression for #43: TEST environment must honor configured hub URLs (previously the
+    // helper short-circuited to a null server_url for non-DISCOVERY env, causing an NPE in
+    // RemoteWebDriver.<init>). The connect attempt itself will still fail since nothing is
+    // listening — but the exception must come from the network layer, not a NullPointerException.
+    BrowserConnectionHelper.setConfiguredSeleniumUrls(
+        new String[] {"http://localhost:4444/wd/hub"});
+    Exception ex =
+        assertThrows(
+            Exception.class,
+            () ->
+                BrowserConnectionHelper.getConnection(BrowserType.CHROME, BrowserEnvironment.TEST));
+    assertFalse(
+        ex instanceof NullPointerException,
+        "TEST environment should not fall through to a null server URL: " + ex);
+  }
+
+  @Test
+  public void testGetConnectionThrowsWhenNoSeleniumUrlsConfigured() {
+    BrowserConnectionHelper.setConfiguredSeleniumUrls(new String[] {});
     assertThrows(
-        Throwable.class,
+        IllegalStateException.class,
         () -> BrowserConnectionHelper.getConnection(BrowserType.CHROME, BrowserEnvironment.TEST));
   }
 
@@ -176,7 +196,11 @@ public class BrowserConnectionHelperTest {
 
   @Test
   public void testSetConfiguredSeleniumUrlsMultiple() {
-    String[] urls = {"hub1.example.com", "hub2.example.com", "hub3.example.com"};
+    String[] urls = {
+      "http://hub1.example.com:4444/wd/hub",
+      "http://hub2.example.com:4444/wd/hub",
+      "http://hub3.example.com:4444/wd/hub"
+    };
     assertDoesNotThrow(() -> BrowserConnectionHelper.setConfiguredSeleniumUrls(urls));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
-          <configuration>
-            <!-- Tags that opt an IT out of the default verify run.
-                 Override locally with `-DexcludedGroups=` to run them.
-                 See SeleniumGridIT for the rationale (#43). -->
-            <excludedGroups>requires-selenium-grid</excludedGroups>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -144,7 +144,7 @@ module "browser_service" {
   database_password_secret_name    = module.postgres.password_secret_name
   database_password_secret_version = module.postgres.password_secret_version_number
 
-  selenium_grid_urls = [for s in module.selenium : s.grid_host]
+  selenium_grid_urls = [for s in module.selenium : s.grid_url]
 
   labels = local.base_labels
 

--- a/terraform/modules/browser_service/variables.tf
+++ b/terraform/modules/browser_service/variables.tf
@@ -109,7 +109,7 @@ variable "database_password_secret_version" {
 }
 
 variable "selenium_grid_urls" {
-  description = "List of bare Selenium hostnames (no scheme, no path) joined with commas into SELENIUM_GRID_URLS. The engine's BrowserConnectionHelper prepends https:// and appends /wd/hub at runtime, so passing fully-qualified URLs would yield https://https://.../wd/hub/wd/hub."
+  description = "List of fully qualified Selenium URLs (scheme + host + /wd/hub) joined with commas into SELENIUM_GRID_URLS. The engine's BrowserConnectionHelper consumes each entry verbatim — no scheme rewriting and no path appending."
   type        = list(string)
 }
 

--- a/terraform/modules/selenium/outputs.tf
+++ b/terraform/modules/selenium/outputs.tf
@@ -8,12 +8,11 @@ output "service_name" {
   value       = google_cloud_run_service.selenium_standalone_chrome.name
 }
 
-output "grid_host" {
-  # The engine's BrowserConnectionHelper#getConnection builds Selenium URLs as
-  # `https://<entry>/wd/hub`, so SELENIUM_GRID_URLS entries must be bare
-  # hostnames (no scheme, no path). Cloud Run terminates TLS at the public
-  # *.run.app hostname on port 443, which matches the engine's hardcoded
-  # `https://`.
-  description = "Bare Selenium host (no scheme, no path) suitable for SELENIUM_GRID_URLS. The engine prepends https:// and appends /wd/hub at runtime."
-  value       = trimprefix(google_cloud_run_service.selenium_standalone_chrome.status[0].url, "https://")
+output "grid_url" {
+  # The engine's BrowserConnectionHelper consumes SELENIUM_GRID_URLS entries
+  # verbatim — they must be fully qualified URLs (scheme + host + path). Cloud
+  # Run terminates TLS at the public *.run.app hostname on port 443, so the
+  # resulting URL is `https://<host>/wd/hub`.
+  description = "Fully qualified Selenium URL (scheme + host + /wd/hub) suitable for SELENIUM_GRID_URLS. Consumed verbatim by the engine."
+  value       = "${google_cloud_run_service.selenium_standalone_chrome.status[0].url}/wd/hub"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,9 +8,9 @@ output "browser_service_name" {
   value       = module.browser_service.service_name
 }
 
-output "selenium_grid_hosts" {
-  description = "Bare Selenium hostnames (no scheme/path) injected into SELENIUM_GRID_URLS on the API. The engine prepends https:// and appends /wd/hub at runtime."
-  value       = [for s in module.selenium : s.grid_host]
+output "selenium_grid_urls" {
+  description = "Fully qualified Selenium URLs (scheme + host + /wd/hub) injected into SELENIUM_GRID_URLS on the API. Consumed verbatim by the engine."
+  value       = [for s in module.selenium : s.grid_url]
 }
 
 output "selenium_service_urls" {


### PR DESCRIPTION
## Summary

Fixes #43.

`BrowserConnectionHelper.getConnection` only consumed the configured Selenium hub URLs when `BrowserEnvironment` was `DISCOVERY`, and even there it hardcoded `https://` and appended `/wd/hub`. For `BrowserEnvironment.TEST` (used by `SeleniumGridIT`), `server_url` stayed null and `RemoteWebDriver` NPE'd — surfaced upstream as a 502 `upstream_unavailable` with a null inner message. Same hardcoded-scheme problem in `getMobileConnection`.

### Engine fix (`BrowserConnectionHelper`)

- Drop the `environment == DISCOVERY` gate; honor `HUB_URLS` for any env when the browser is chrome/firefox.
- Treat `HUB_URLS` and `APPIUM_URLS` entries as fully qualified URLs (scheme + host + path) and use them verbatim — no scheme rewriting, no `/wd/hub` appending. Matches the existing default `http://localhost:4444/wd/hub` already in `EngineProperties.SeleniumProps`.
- Throw `IllegalStateException` when chrome/firefox is requested but no Selenium URLs are configured (replaces the silent NPE).
- Use `Math.floorMod` for round-robin to stay safe under int overflow.

The `environment` parameter stays in the signature — many callers pass it and it's reserved for future per-env routing.

### Re-enable `SeleniumGridIT` in CI

- Drop `@Tag("requires-selenium-grid")` and the now-obsolete header comment.
- Drop `<excludedGroups>requires-selenium-grid</excludedGroups>` from the failsafe plugin in the root `pom.xml`.
- CI workflow needs no change — it already runs `mvn ... verify` with no `-DexcludedGroups=` override.

### Doc / contract change

`browserservice.selenium.urls` and `browserservice.appium.urls` must now be **full URLs** including scheme and path (e.g. `http://host:4444/wd/hub`). Documented in:
- `BrowserConnectionHelper.setConfiguredSeleniumUrls` / `setConfiguredAppiumUrls` javadoc
- `EngineProperties.SeleniumProps` / `AppiumProps` record-level javadoc

(`application.yaml` comments aren't viable — Spotless's Jackson YAML formatter strips them.)

### Tests

- Updated `BrowserConnectionHelperTest` fixtures to full URLs.
- Repurposed `testGetConnectionWithTestEnvironment` → `testGetConnectionWithTestEnvironmentChromeUsesConfiguredUrl` as the regression test for #43; asserts no NPE escapes when `BrowserEnvironment.TEST` is used.
- Added `testGetConnectionThrowsWhenNoSeleniumUrlsConfigured` to cover the empty-guard.

Out of scope (per issue): pinning `selenium/standalone-chrome` to a specific version.

## Test plan

- [x] `./mvnw -B -ntp -pl engine test -Dtest=BrowserConnectionHelperTest` — 16/16 pass.
- [x] `./mvnw -B -ntp test` — 273/273 unit tests pass across both modules.
- [x] `./mvnw -B -ntp spotless:check` — clean.
- [ ] CI `mvn verify` — confirm `SeleniumGridIT` runs (not skipped) and the create → navigate → screenshot → delete flow succeeds against the Testcontainers `selenium/standalone-chrome`. Local `verify` couldn't be exercised here because no Docker daemon is running in this environment; CI has Docker.
- [ ] Confirm in CI logs: no `NullPointerException` from `RemoteWebDriver.<init>`, and the `SeleniumGridIT` line appears in the failsafe summary.

https://claude.ai/code/session_014MKDL8Vw5N7HYKPFyMNoXf

---
_Generated by [Claude Code](https://claude.ai/code/session_014MKDL8Vw5N7HYKPFyMNoXf)_