### PR TITLE
build(api): close out Quarkus migration Step 1 (#14) wiring

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,6 +43,9 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-scheduler</artifactId>
     </dependency>
+    <!-- Spring Data JPA compatibility layer; required while
+         BrowserSessionRepository still extends JpaRepository. Removed in #18
+         when persistence is rewritten to Panache. -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-spring-data-jpa</artifactId>
@@ -67,6 +70,9 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
+    <!-- Legacy JSR-356 extension matches the current SessionWebSocketHandler
+         (@ServerEndpoint, jakarta.websocket.*). Swapped to
+         quarkus-websockets-next in #20 alongside the @WebSocket rewrite. -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-websockets</artifactId>
@@ -218,7 +224,6 @@
         <version>${jacoco.version}</version>
         <configuration>
           <excludes>
-            <exclude>io/browserservice/api/BrowserServiceApplication.class</exclude>
             <exclude>io/browserservice/api/dto/**</exclude>
           </excludes>
         </configuration>


### PR DESCRIPTION
## Summary

Closes out Quarkus migration Step 1 (#14). The build wiring described in #14 — Quarkus BOM, `quarkus-maven-plugin`, every prescribed Quarkus extension, and removal of `spring-boot-starter-*` / `springdoc-openapi-*` / direct `flyway-core` / direct `micrometer-registry-prometheus` — was already in place from prior work. Both acceptance criteria pass on the current tree:

- `./mvnw -pl api -B -ntp dependency:tree` → BUILD SUCCESS; tree shows Quarkus extensions only, no Spring Boot starters.
- `./mvnw -pl api -am -B -ntp -DskipTests compile` → BUILD SUCCESS, 117 source files.

This PR is a small wiring tidy that documents the two intentional deviations from #14's literal checklist and removes one dead config entry:

- `quarkus-spring-data-jpa` — `api/pom.xml` carries this so `BrowserSessionRepository` (still `extends JpaRepository`) compiles. The dependency goes away in #18 alongside the Panache rewrite. Comment added.
- `quarkus-websockets` (legacy JSR-356) — matches the current `SessionWebSocketHandler` (`@ServerEndpoint`, `jakarta.websocket.*`). Swap to `quarkus-websockets-next` happens in #20 with the `@WebSocket` rewrite. Comment added.
- JaCoCo exclude on `io/browserservice/api/BrowserServiceApplication.class` — the Spring Boot entry point no longer exists; orphan exclude removed.

Two other items from #14's checklist:
- `quarkus-resteasy-reactive-jackson` is the same artifact as `quarkus-rest-jackson`, just renamed in Quarkus 3.9+. The current name is correct.
- `quarkus-spring-scheduled` was prescribed by #14, but `BrowserSessionTracker` and `SessionReaper` already use `io.quarkus.scheduler.Scheduled` (Quarkus-native), so `quarkus-scheduler` is the right dependency. No change.

## Test plan

- [x] `./mvnw -pl api -am -B -ntp -DskipTests compile` exits 0
- [x] `./mvnw -pl api -am -B -ntp spotless:check checkstyle:check` exits 0
- [ ] CI green on the PR (full `verify` cycle including spotbugs, pmd, surefire, failsafe, jacoco-check)
- [ ] After merge, comment on #14 with verification output and close

https://claude.ai/code/session_012qY3Q93prGXBugAuP1qrqD

---
_Generated by [Claude Code](https://claude.ai/code/session_012qY3Q93prGXBugAuP1qrqD)_