### PR TITLE
build(api): Quarkus migration Step 2 (#15) — application config

### DIFF
--- a/api/src/main/java/io/browserservice/api/config/EnginePropertiesProducer.java
+++ b/api/src/main/java/io/browserservice/api/config/EnginePropertiesProducer.java
@@ -50,16 +50,17 @@ public class EnginePropertiesProducer {
       @ConfigProperty(name = "browserservice.selenium.implicit-wait-seconds", defaultValue = "10")
           int seleniumImplicitWaitSeconds,
       // appium
-      @ConfigProperty(name = "browserservice.appium.urls", defaultValue = "") String appiumUrls,
       @ConfigProperty(name = "browserservice.appium.platform", defaultValue = "ANDROID")
           String appiumPlatform,
-      @ConfigProperty(name = "browserservice.appium.device-name", defaultValue = "")
-          String appiumDeviceName,
       @ConfigProperty(name = "browserservice.appium.connect-timeout-ms", defaultValue = "60000")
           int appiumConnectTimeoutMs,
       @ConfigProperty(name = "browserservice.appium.max-retries", defaultValue = "3")
           int appiumMaxRetries,
       Config config) {
+    // appium.urls and appium.device-name route through Config.getOptionalValue
+    // because SmallRye Config rejects an empty defaultValue on @ConfigProperty.
+    String appiumUrls = str(config, "browserservice.appium.urls", "");
+    String appiumDeviceName = str(config, "browserservice.appium.device-name", "");
     return new EngineProperties(
         new EngineProperties.SessionProps(
             idleTtlSeconds, absoluteTtlSeconds, maxConcurrent, lockAcquireTimeoutMs),

--- a/api/src/main/java/io/browserservice/api/config/JacksonConfig.java
+++ b/api/src/main/java/io/browserservice/api/config/JacksonConfig.java
@@ -1,22 +1,24 @@
 package io.browserservice.api.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 import jakarta.inject.Singleton;
 
+/**
+ * Canonical Jackson configuration for the Quarkus runtime: snake_case property naming, ISO-8601
+ * dates (not numeric timestamps), and {@code non_null} serialization inclusion. Spring's {@code
+ * spring.jackson.*} YAML keys aren't honoured by Quarkus, so the wire-format settings live here in
+ * code rather than {@code application.yaml}.
+ */
 @Singleton
 public class JacksonConfig implements ObjectMapperCustomizer {
 
   @Override
   public void customize(com.fasterxml.jackson.databind.ObjectMapper mapper) {
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-    // The HTTP/WS contract is snake_case (session_id, browser_type, owner_id, ...);
-    // historically declared in application.yaml as
-    // `spring.jackson.property-naming-strategy: SNAKE_CASE`. Quarkus does not honour
-    // that Spring key, so we apply the strategy programmatically to keep the wire
-    // format stable across the Spring -> Quarkus migration regardless of when the
-    // YAML rewrite (#15) lands.
     mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 }

--- a/api/src/main/java/io/browserservice/api/config/MicrometerCommonTagsConfig.java
+++ b/api/src/main/java/io/browserservice/api/config/MicrometerCommonTagsConfig.java
@@ -1,0 +1,22 @@
+package io.browserservice.api.config;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.config.MeterFilter;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import java.util.List;
+
+/**
+ * Tags every metric with {@code application=browser-service-api} so Prometheus scrapes can
+ * distinguish this service from siblings sharing a registry. Replaces the Spring-only {@code
+ * management.metrics.tags.application} YAML key, which Quarkus does not honour.
+ */
+public class MicrometerCommonTagsConfig {
+
+  /** Produces the common-tag filter the micrometer extension applies to every registered meter. */
+  @Produces
+  @Singleton
+  public MeterFilter applicationTagFilter() {
+    return MeterFilter.commonTags(List.of(Tag.of("application", "browser-service-api")));
+  }
+}

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -48,11 +48,14 @@ browserservice:
     implicit-wait-enabled: false
     implicit-wait-seconds: 10
   appium:
+    urls: "${APPIUM_URLS:}"
     platform: "ANDROID"
     connect-timeout-ms: 60000
     max-retries: 3
   browserstack:
     enabled: false
+    username: "${BROWSERSTACK_USERNAME:}"
+    access-key: "${BROWSERSTACK_ACCESS_KEY:}"
     real-mobile: true
     local: false
     debug: true

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -1,34 +1,39 @@
 ---
-server:
-  port: 8080
-  forward-headers-strategy: "framework"
-spring:
+quarkus:
   application:
     name: "browser-service-api"
-  threads:
-    virtual:
+  http:
+    port: 8080
+    proxy:
+      proxy-address-forwarding: true
+    access-log:
       enabled: true
-  jackson:
-    property-naming-strategy: "SNAKE_CASE"
-    default-property-inclusion: "non_null"
-    serialization:
-      write-dates-as-timestamps: false
   datasource:
-    url: "${DATABASE_URL:jdbc:postgresql://localhost:5432/browser_service}"
+    db-kind: "postgresql"
     username: "${DATABASE_USERNAME:browser_service}"
     password: "${DATABASE_PASSWORD:browser_service}"
-  jpa:
-    hibernate:
-      ddl-auto: "validate"
-    properties:
-      hibernate:
-        jdbc:
-          time_zone: "UTC"
-        format_sql: false
-    open-in-view: false
+    jdbc:
+      url: "${DATABASE_URL:jdbc:postgresql://localhost:5432/browser_service}"
+  hibernate-orm:
+    database:
+      generation: "validate"
+    jdbc:
+      timezone: "UTC"
+    log:
+      format-sql: false
   flyway:
-    enabled: true
+    migrate-at-start: true
     locations: "classpath:db/migration"
+  smallrye-openapi:
+    path: "/v3/api-docs"
+  swagger-ui:
+    path: "/swagger-ui.html"
+    always-include: true
+  micrometer:
+    export:
+      prometheus:
+        path: "/metrics"
+        enabled: true
 browserservice:
   session:
     idle-ttl-seconds: 300
@@ -43,16 +48,11 @@ browserservice:
     implicit-wait-enabled: false
     implicit-wait-seconds: 10
   appium:
-    urls: "${APPIUM_URLS:}"
     platform: "ANDROID"
-    device-name: ""
     connect-timeout-ms: 60000
     max-retries: 3
   browserstack:
     enabled: false
-    hub-url: ""
-    username: "${BROWSERSTACK_USERNAME:}"
-    access-key: "${BROWSERSTACK_ACCESS_KEY:}"
     real-mobile: true
     local: false
     debug: true
@@ -70,27 +70,3 @@ browserservice:
     navigation-poll-ms: 2000
     watcher-lock-timeout-ms: 50
     max-binary-frame-bytes: 16777216
-management:
-  endpoints:
-    web:
-      base-path: "/"
-      exposure:
-        include: "prometheus"
-      path-mapping:
-        prometheus: "metrics"
-  prometheus:
-    metrics:
-      export:
-        enabled: true
-  metrics:
-    tags:
-      application: "browser-service-api"
-springdoc:
-  api-docs:
-    path: "/v3/api-docs"
-    enabled: true
-  swagger-ui:
-    path: "/swagger-ui.html"
-    enabled: true
-  paths-to-exclude:
-  - "/metrics"

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -9,8 +9,6 @@
   fix the violation at the source instead.
 -->
 <suppressions>
-  <suppress files="api[/\\]src[/\\]main[/\\]java[/\\]io[/\\]browserservice[/\\]api[/\\]BrowserServiceApplication\.java$" checks="MissingJavadocMethod"/>
-  <suppress files="api[/\\]src[/\\]main[/\\]java[/\\]io[/\\]browserservice[/\\]api[/\\]BrowserServiceApplication\.java$" checks="MissingJavadocType"/>
   <suppress files="api[/\\]src[/\\]main[/\\]java[/\\]io[/\\]browserservice[/\\]api[/\\]config[/\\]EngineConfig\.java$" checks="MissingJavadocMethod"/>
   <suppress files="api[/\\]src[/\\]main[/\\]java[/\\]io[/\\]browserservice[/\\]api[/\\]config[/\\]EngineConfig\.java$" checks="MissingJavadocType"/>
   <suppress files="api[/\\]src[/\\]main[/\\]java[/\\]io[/\\]browserservice[/\\]api[/\\]config[/\\]EngineProperties\.java$" checks="MissingJavadocType"/>


### PR DESCRIPTION
Closes #15.

Step 2 of the Spring Boot → Quarkus 3 migration tracked in #13. Step 1 (#14) swapped the BOM/extensions and deleted `BrowserServiceApplication`. The app was booting only because `quarkus-spring-di` + `quarkus-spring-web` interpret the Spring annotations — `application.yaml` was still keyed under `server.*`/`spring.*`/`management.*`/`springdoc.*`, which Quarkus silently ignored.

This PR makes the YAML authoritative under the `quarkus.*` namespace so dev-mode boot is deterministic.

## Summary

- Rewrite `api/src/main/resources/application.yaml`: drop all `server.*`/`spring.*`/`management.*`/`springdoc.*` keys, add the equivalent `quarkus.http` / `quarkus.datasource` / `quarkus.hibernate-orm` / `quarkus.flyway` / `quarkus.smallrye-openapi` / `quarkus.swagger-ui` / `quarkus.micrometer` keys. `browserservice.*` keys preserved verbatim.
- `JacksonConfig`: add `SerializationInclusion=NON_NULL` alongside the existing `SNAKE_CASE` / `WRITE_DATES_AS_TIMESTAMPS=false` customizations. Quarkus does not honour `spring.jackson.*` keys, so this class is the canonical Jackson source.
- New `MicrometerCommonTagsConfig`: produces a `MeterFilter` tagging every metric with `application=browser-service-api`, replacing `management.metrics.tags.application`.
- `EnginePropertiesProducer`: route `appium.urls` and `appium.device-name` through `Config.getOptionalValue` instead of `@ConfigProperty(defaultValue = "")`. SmallRye Config 3.x treats an empty `defaultValue` as "no default" and rejects the missing/empty key — same helper pattern as the existing `browserstack.*` params.
- Drop two stale checkstyle suppressions for the long-deleted `BrowserServiceApplication.java`.

## Key migration table

| From (Spring)                                         | To (Quarkus)                                                |
| ----------------------------------------------------- | ----------------------------------------------------------- |
| `server.port`                                         | `quarkus.http.port`                                         |
| `server.forward-headers-strategy`                     | `quarkus.http.proxy.proxy-address-forwarding`               |
| `spring.application.name`                             | `quarkus.application.name`                                  |
| `spring.datasource.url`                               | `quarkus.datasource.jdbc.url`                               |
| `spring.datasource.username/password`                 | `quarkus.datasource.username/password`                      |
| `spring.jpa.hibernate.ddl-auto: validate`             | `quarkus.hibernate-orm.database.generation: validate`       |
| `spring.jpa.properties.hibernate.jdbc.time_zone`      | `quarkus.hibernate-orm.jdbc.timezone`                       |
| `spring.flyway.enabled: true`                         | `quarkus.flyway.migrate-at-start: true`                     |
| `springdoc.api-docs.path`                             | `quarkus.smallrye-openapi.path`                             |
| `springdoc.swagger-ui.path`                           | `quarkus.swagger-ui.path` + `swagger-ui.always-include`     |
| `management.*` (prometheus)                           | `quarkus.micrometer.export.prometheus.path`                 |
| `management.metrics.tags.application`                 | `MicrometerCommonTagsConfig` `MeterFilter` bean             |
| `spring.jackson.*`                                    | `JacksonConfig` `ObjectMapperCustomizer` (already in place) |
| `browserservice.*`                                    | unchanged                                                   |

Added per the issue: `quarkus.http.access-log.enabled: true`.

`spring.threads.virtual.enabled` is dropped without a Quarkus replacement: there is no global virtual-threads toggle in Quarkus 3.15. Per-endpoint `@RunOnVirtualThread` will be addressed alongside the controller cleanup in #17 if/when needed.

## Out of scope

- `application-test.yaml` rewrite — deferred to #24 (Step 11: Tests). Spring keys there are silently ignored by Quarkus today; non-DB unit tests pass unchanged.
- `EngineConfig` `@Configuration`/`@Bean` → CDI conversion — deferred to #17 (Step 4: Services and components). Currently works through `quarkus-spring-di`.
- OpenAPI metadata move from `OpenApiConfig.java` to YAML — deferred to #23 (Step 10: OpenAPI). The MP-OpenAPI annotations in `OpenApiConfig` already produce the spec.

## Test plan

- [x] `./mvnw -am -pl api package -DskipTests` — Quarkus augmentation succeeds with no unrecognized `quarkus.*` warnings.
- [x] `./mvnw -am -pl api test` — 166 tests pass.
- [x] `./mvnw -am -pl api spotless:check checkstyle:check` — clean.
- [x] `./mvnw -pl api spotbugs:check pmd:check` — clean.
- [x] `java -jar api/target/quarkus-app/quarkus-run.jar` — boots through full config resolution; `browserservice.*` keys resolve via `EnginePropertiesProducer`; Quarkus then attempts a Postgres connection at `localhost:5432/browser_service` (no Postgres in this env, so startup stops there as expected).
- [ ] **Reviewer to verify on a host with Docker:** `./mvnw -pl api quarkus:dev` should fully boot once Postgres is reachable; `curl :8080/healthz`, `:8080/v3/api-docs`, `:8080/swagger-ui.html`, `:8080/metrics` should each return 200 and `:8080/metrics` should include the `application="browser-service-api"` tag.

https://claude.ai/code/session_01XV2fRojrikJSHdZh24hdoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV2fRojrikJSHdZh24hdoV)_