### PR TITLE
chore(compose): bundle Selenium standalone-chrome with Postgres + API

### DIFF
--- a/API_TESTING.md
+++ b/API_TESTING.md
@@ -43,44 +43,32 @@ Both run in Docker containers below.
 
 ## 2. Bring up the dependencies
 
-### Postgres
-
-`docker-compose.yml` ships a Postgres on host port **5433** so it does not
-collide with anything you already run on `5432`:
+`docker-compose.yml` ships both upstreams the API needs — Postgres (host port
+**5433** to avoid colliding with anything on `5432`) and a Selenium standalone
+Chrome (host ports **4444** for the WebDriver hub and **7900** for noVNC).
+Bring them both up together:
 
 ```bash
-docker compose up -d postgres
+docker compose up -d postgres selenium
 ```
 
-Verify:
+Verify Postgres:
 
 ```bash
 docker compose ps postgres
 docker compose exec postgres pg_isready -U browser_service -d browser_service
 ```
 
-### Selenium Grid (Chrome)
-
-The default config points at `http://localhost:4444/wd/hub`. The simplest way
-to satisfy that is the Selenium standalone image:
+Verify Selenium:
 
 ```bash
-docker run -d --rm --name selenium-chrome \
-  -p 4444:4444 -p 7900:7900 \
-  --shm-size=2g \
-  selenium/standalone-chrome:latest
-```
-
-- `4444` — WebDriver hub.
-- `7900` — noVNC (open `http://localhost:7900`, password `secret`) so you can
-  watch the browser drive itself while you test.
-
-Verify:
-
-```bash
+docker compose ps selenium
 curl -s http://localhost:4444/status | jq .value.ready
 # -> true
 ```
+
+Open `http://localhost:7900` (password `secret`) to watch the browser drive
+itself while you run the walkthrough below.
 
 Appium is **not** required unless you want to drive `ANDROID` / `IOS` sessions.
 Leave `APPIUM_URLS` unset and stick to `CHROME`.
@@ -107,18 +95,18 @@ DATABASE_URL=jdbc:postgresql://localhost:5433/browser_service \
 java -jar api/target/browser-service-api-*-exec.jar
 ```
 
-### C. Full docker-compose (api + postgres in containers)
+### C. Full docker-compose (api + postgres + selenium in containers)
 
 ```bash
 docker compose up -d --build
 ```
 
-This exposes the API on **host port 9999** (mapped to container `8080`). Every
-example below assumes the local-Maven setup on `:8080` — substitute `:9999` if
-you go this route. Note that the containerised API will resolve
-`http://localhost:4444` from inside the container, not the host, so you will
-also need to either run Selenium in the same compose network or pass
-`-e SELENIUM_GRID_URLS=http://host.docker.internal:4444/wd/hub`.
+This brings up Postgres, the Selenium standalone Chrome, **and** the API in
+one shot. No extra `docker run` needed. The API is exposed on **host port
+9999** (mapped to container `8080`); every example below assumes the
+local-Maven setup on `:8080`, so substitute `:9999` if you go this route. The
+API service is wired with `SELENIUM_GRID_URLS=http://selenium:4444/wd/hub` so
+it talks to the Selenium container over the compose network.
 
 ### Pick a caller ID
 
@@ -426,7 +414,7 @@ open api/target/site/jacoco/index.html
 | `404 session_not_found` | Session was closed or never existed | Open a new one. |
 | `410 session_expired` | Idle (5 min) or absolute (30 min) TTL fired | Open a new one. |
 | `429 session_cap_exceeded` | More than 20 concurrent sessions for this caller (see `application.yaml`) | Close some. |
-| `502 upstream_unavailable` on `POST /v1/sessions` | Selenium hub not reachable | `curl http://localhost:4444/status`; check the `selenium-chrome` container. |
+| `502 upstream_unavailable` on `POST /v1/sessions` | Selenium hub not reachable | `curl http://localhost:4444/status`; check the `selenium` compose service. |
 | `readyz` returns 503 | Postgres or Selenium probe failed | Inspect the JSON body — it names the failing dependency. |
 | App fails to boot with `password authentication failed` / `Connection refused` on `:5432` | Postgres is on host `:5433` from compose, but the app's default is `:5432` | Pass `--spring.datasource.url=jdbc:postgresql://localhost:5433/browser_service` (see § 3.A). |
 | WebSocket handshake closed immediately | Missing `X-Caller-Id` header on the upgrade | Pass it via `-H` to `websocat`. |

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ Browser interactions are inherently **stateful** — checking email, filling out
 ## 🚀 Quick start
 
 ```bash
-# Build and run locally (brings up Postgres + the API together)
+# Build and run locally (brings up Postgres, Selenium, and the API together)
 ./mvnw clean verify
 docker compose up
 ```
 
-Compose publishes the API on host port **9999** — browse <http://localhost:9999/swagger-ui.html>.
+Compose publishes the API on host port **9999** — browse <http://localhost:9999/swagger-ui.html>. The bundled Selenium standalone Chrome is published on **4444** (WebDriver hub) and **7900** (noVNC, password `secret`), so you can watch sessions drive themselves while you test.
 
-To point at an external Selenium Grid, add `SELENIUM_GRID_URLS=http://your-grid:4444/wd/hub` to the `api` service's `environment:` block in `docker-compose.yml` (the app reads `browserservice.selenium.urls` from that variable). For deployments without Compose, the app needs at minimum a reachable `DATABASE_URL` and `SELENIUM_GRID_URLS` — see `api/src/main/resources/application.yaml` for the full env-var surface.
+To point at an **external** Selenium Grid instead of the bundled one, override `SELENIUM_GRID_URLS` on the `api` service in `docker-compose.yml` (the app reads `browserservice.selenium.urls` from that variable) — e.g. `SELENIUM_GRID_URLS=http://your-grid:4444/wd/hub`. For deployments without Compose, the app needs at minimum a reachable `DATABASE_URL` and `SELENIUM_GRID_URLS` — see `api/src/main/resources/application.yaml` for the full env-var surface.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,21 @@ services:
       retries: 10
     restart: unless-stopped
 
+  selenium:
+    image: selenium/standalone-chrome:latest
+    container_name: browser-service-selenium
+    shm_size: 2gb
+    ports:
+      - "4444:4444"
+      - "7900:7900"
+    healthcheck:
+      test: ["CMD", "/opt/bin/check-grid.sh", "--host", "0.0.0.0", "--port", "4444"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 30s
+    restart: unless-stopped
+
   api:
     build:
       context: .
@@ -26,10 +41,13 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      selenium:
+        condition: service_healthy
     environment:
       DATABASE_URL: jdbc:postgresql://postgres:5432/browser_service
       DATABASE_USERNAME: browser_service
       DATABASE_PASSWORD: browser_service
+      SELENIUM_GRID_URLS: http://selenium:4444/wd/hub
     ports:
       - "9999:8080"
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Previously the docs (`API_TESTING.md` §2) instructed users to run the Selenium standalone Chrome container by hand via `docker run` before bringing up the API. This PR folds that container into `docker-compose.yml` so a single `docker compose up` brings up Postgres, Selenium, and the API together.

### What changed

- **`docker-compose.yml`** — new `selenium` service running `selenium/standalone-chrome:latest`:
  - `shm_size: 2gb` (Chrome crashes without it).
  - Ports `4444` (WebDriver hub) and `7900` (noVNC, password `secret`) are still published to the host so existing manual testing flows keep working.
  - Healthcheck uses the image's bundled `/opt/bin/check-grid.sh` script with a 30s `start_period` (the image takes ~15–20s to come up).
- **`api` service** — now sets `SELENIUM_GRID_URLS=http://selenium:4444/wd/hub` and `depends_on: { selenium: { condition: service_healthy } }`, so it won't start until the hub is ready.
- **`API_TESTING.md`** — replaces the standalone `docker run selenium/standalone-chrome` step with `docker compose up -d postgres selenium`, and removes the stale note about needing `host.docker.internal` for the containerised API path.
- **`README.md`** — quick-start comment now reads "brings up Postgres, Selenium, and the API together" and explains how to override `SELENIUM_GRID_URLS` if you want to point at an external grid instead of the bundled one.

```mermaid
graph LR
    U[docker compose up] --> P[postgres :5433]
    U --> S[selenium :4444/:7900]
    U --> A[api :9999]
    A -->|DATABASE_URL| P
    A -->|SELENIUM_GRID_URLS| S
```

## Test plan

- [ ] `docker compose config --quiet` parses cleanly (verified locally).
- [ ] `docker compose up -d` brings all three services up; `api` waits for `selenium` to be healthy before booting.
- [ ] `curl http://localhost:4444/status | jq .value.ready` returns `true`.
- [ ] `curl http://localhost:9999/readyz` returns 200 once everything is up.
- [ ] Open a session against `:9999` with `X-Caller-Id: me` and confirm the bundled hub provisions a Chrome (visible at `http://localhost:7900`, password `secret`).
- [ ] An external-grid override still works: set `SELENIUM_GRID_URLS=http://your-grid:4444/wd/hub` on the `api` service and confirm sessions land on the external grid.

https://claude.ai/code/session_01Wo9EJeDNVyusJKr3oQVGut

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo9EJeDNVyusJKr3oQVGut)_