### PR TITLE
build(api): %dev H2 fallback + Step 3 smoke findings (#16)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -138,10 +138,13 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- 'provided' (not 'test') so `quarkus:dev` can boot against in-memory
+         H2 when Docker / Dev Services / Postgres are unavailable locally.
+         Excluded from the production uber-jar — runtime uses postgresql. -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-h2</artifactId>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <!-- 'provided' (not 'test') so `quarkus:dev` can boot against in-memory
          H2 when Docker / Dev Services / Postgres are unavailable locally.

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -34,11 +34,7 @@ quarkus:
       prometheus:
         path: "/metrics"
         enabled: true
-# Dev-mode override: when Docker (and therefore Dev Services / Postgres) is
-# unavailable, fall back to an in-memory H2 instance so `quarkus:dev` boots
-# for local smoke. Requires quarkus-jdbc-h2 on the dev classpath (scope
-# 'provided' in pom.xml). Production keeps the postgresql defaults above.
-"%dev":
+'%dev':
   quarkus:
     datasource:
       db-kind: "h2"

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -34,6 +34,25 @@ quarkus:
       prometheus:
         path: "/metrics"
         enabled: true
+# Dev-mode override: when Docker (and therefore Dev Services / Postgres) is
+# unavailable, fall back to an in-memory H2 instance so `quarkus:dev` boots
+# for local smoke. Requires quarkus-jdbc-h2 on the dev classpath (scope
+# 'provided' in pom.xml). Production keeps the postgresql defaults above.
+"%dev":
+  quarkus:
+    datasource:
+      db-kind: "h2"
+      username: "sa"
+      password: ""
+      devservices:
+        enabled: false
+      jdbc:
+        url: "jdbc:h2:mem:browser_service_dev;MODE=PostgreSQL;DB_CLOSE_DELAY=-1"
+    flyway:
+      migrate-at-start: false
+    hibernate-orm:
+      database:
+        generation: "drop-and-create"
 browserservice:
   session:
     idle-ttl-seconds: 300


### PR DESCRIPTION
## Summary

Re-runs the deferred curl smoke from PR #63 against issue #16 ("Quarkus migration Step 3: HTTP layer"). PR #63's commit message explicitly noted: *"full curl smoke deferred — Docker not available in this environment, no Postgres to boot against."* This PR adds the missing dev-mode boot strategy so the smoke can run locally without Docker, then documents what the smoke uncovered.

**TL;DR — #16's acceptance criteria are NOT met by the current `main`.** Eight runtime regressions are visible the moment the app boots and you `curl` the routes. Listing them here so we can scope follow-ups rather than silently shipping.

## Code change (in-scope, 2 files / +23 −1 lines)

| File | Why |
|---|---|
| `api/src/main/resources/application.yaml` | `%dev` profile override → in-memory H2 (`MODE=PostgreSQL`, `drop-and-create`, Flyway off) so `quarkus:dev` boots without Docker/Postgres. |
| `api/pom.xml` | `quarkus-jdbc-h2` scope `test` → `provided`. Available to dev mode (compile + test classpath); still excluded from the production uber-jar. |

`./mvnw -pl api -am clean verify` passes (22 tests, Spotless/Checkstyle/PMD/SpotBugs clean, JaCoCo ≥ 0.40).

## Boot recipe (for whoever picks up the follow-ups)

```bash
./mvnw install -DskipTests -Dspotless.check.skip -Dcheckstyle.skip -Dpmd.skip -Dspotbugs.skip -Djacoco.skip
./mvnw -pl api quarkus:dev    # listens on :8080, profile dev, jdbc-h2 active
```

## Findings against the route-mount sweep

`ErrorMapper` (`api/src/main/java/io/browserservice/api/error/ErrorMapper.java`) is the contract source of truth: `caller_unidentified → 400`, `validation_failed → 400`, `session_not_found → 404`, `element_not_found → 404`, `upstream_timeout → 408`, `unhandled_alert → 409`, `stale_element → 409`, `upstream_unavailable → 502`, `webdriver_error → 502`, `internal_error → 500`.

### F1 — `@RequestHeader CallerId caller` is not bound (CRITICAL)

The `CallerIdParamConverterProvider` is never invoked by `quarkus-spring-web`. Every `/v1/*` endpoint accepts requests without `X-Caller-Id`:

```text
$ curl -i http://localhost:8080/v1/sessions
HTTP/1.1 200 OK
X-Request-Id: 1cd7ef8c-…
{"sessions":[]}

$ curl -i -H "X-Caller-Id: $(printf 'a%.0s' {1..200})" http://localhost:8080/v1/sessions
HTTP/1.1 200 OK   # 200 chars >> MAX_LENGTH=128 — converter would have thrown
{"sessions":[]}
```

Expected (per `CallerUnidentifiedException`): **400 `caller_unidentified`** on empty/missing/oversized header. Got 200 with `null` caller flowing through. Effectively, the caller-id ownership check is bypassed for every endpoint.

Root cause hypothesis: `quarkus-spring-web` translates `@RequestHeader(name) ComplexType` to `@HeaderParam(name) ComplexType` at build time but does not route the binding through registered `ParamConverterProvider`s. `CallerId.parse(String)` is not named `valueOf`/`fromString` and the constructor is private, so the JAX-RS standard conversion paths don't match either.

### F2 — `GET /v1/sessions/{id}` and `DELETE /v1/sessions/{id}` return 500 (CRITICAL)

```text
$ curl -i -H "X-Caller-Id: alice" http://localhost:8080/v1/sessions/00000000-0000-0000-0000-000000000000
HTTP/1.1 500 Internal Server Error
{"error":{"code":"internal_error","message":"an unexpected error occurred"}}
```

Server log:

```text
ERROR [io.bro.api.err.ErrorMapper] unexpected error:
  jakarta.ws.rs.NotFoundException: Unable to find matching target resource method
    at org.jboss.resteasy.reactive.server.handlers.ClassRoutingHandler.throwNotFound
```

The OpenAPI spec lists `/v1/sessions/{id}` with `GET` and `DELETE`. RESTEasy can't dispatch them at runtime — spec/router mismatch. Sibling routes work (`/v1/sessions/{id}/status`, `/v1/sessions/{id}/alert`, etc. — all 404 cleanly). The break is specific to `SessionsController`, where class-level `@RequestMapping("/v1/sessions")` (no path var) combines with method-level `@GetMapping("/{id}")` / `@DeleteMapping("/{id}")`.

### F3 — `POST /v1/sessions/{id}/element/screenshot` returns 500

Same `NotFoundException: Unable to find matching target resource method`. Sibling `POST /v1/sessions/{id}/screenshot` on the same controller (`ScreenshotsController`) works. The two `@PostMapping` methods on one class with different sub-paths are not both reachable.

### F4 — Bean Validation 400s don't use `ErrorResponse` shape

```text
$ curl -X POST -H "Content-Type: application/json" -d '{}' \
       -H "X-Caller-Id: alice" http://localhost:8080/v1/sessions
HTTP/1.1 400 Bad Request
Content-Type: application/json;charset=UTF-8
validation-exception: true
{"title":"Constraint Violation","status":400,
 "violations":[{"field":"create.req.browserType","message":"must not be null"}, …]}
```

RESTEasy's built-in `ConstraintViolationException` mapper wins over the project's `GlobalExceptionHandler ExceptionMapper<Throwable>` (more specific exception type). Result: clients see RFC-7807-style bodies for some 400s and `ErrorResponse` for others. `ErrorMapper.map(ConstraintViolationException, …)` is never reached.

### F5 — JAX-RS-raised 5xx responses lose `X-Request-Id` and `error.request_id`

For F2/F3 cases, response headers contain neither `X-Request-Id` nor `Vary`/`Set-Cookie`, and the body's `error.request_id` is absent:

```text
HTTP/1.1 500 Internal Server Error
Content-Type: application/json;charset=UTF-8
content-length: 76
{"error":{"code":"internal_error","message":"an unexpected error occurred"}}
```

Compared with a "good" 404 (`/v1/sessions/{id}/status`), which carries the header and body field correctly. The `RequestIdFilter` response chain is bypassed when the exception is raised before resource-method dispatch.

### F6 — `NotAcceptableException` and similar JAX-RS errors map to 500

`POST /v1/capture` with default `Accept: application/json` throws `jakarta.ws.rs.NotAcceptableException` ("The accept header value did not match the value in @Produces") which becomes `internal_error / 500` instead of `406`. `ErrorMapper` has no case for these JAX-RS standard exceptions.

### F7 — `GET /v1/capture/{captureId}/screenshot` returns `ErrorResponse.toString()` body

```text
HTTP/1.1 404 Not Found
Content-Type: image/png
ErrorResponse[error=ErrorDetail[code=capture_not_found, message=capture not found: …,
  details={capture_id=…}, requestId=…]]
```

Body is Java record `toString()`, not JSON. The endpoint declares `produces = IMAGE_PNG_VALUE` and Jackson's `MessageBodyWriter` doesn't get selected for the error path; RESTEasy falls back to `Object.toString()`.

### F8 — Duplicate `operationId` warnings on every operation (cosmetic)

```text
WARN SROAP07903: Duplicate operationId: getSession produced by Class: SessionsController, Method: get(…)
                 and Class: SessionsController, Method: get(…)
```

Same class + same method appears twice in the OpenAPI scan. Likely the scanner runs over `@RestController` once via Spring annotations and again via the JAX-RS bridge. The emitted spec looks correct (paths/methods unique), so this is noise — but worth filing.

## Captured route matrix

Reproducible via `bash /tmp/smoke.sh` while `quarkus:dev` is running. Headline counts:

| Outcome | Routes |
|---|---|
| Returns expected `session_not_found` 404 with `ErrorResponse` body and matching `request_id` | 7 |
| Returns 400 with non-standard `Constraint Violation` body (F4) | 11 |
| Returns 500 from `NotFoundException` / `NotAcceptableException` (F2/F3/F6) | 5 (sessions/{id} ×2, element/screenshot, capture, capture/{id}/screenshot) |
| Accepts request without `X-Caller-Id` regardless of contract (F1) | All 21 `/v1/*` |
| `/healthz` 200, `/readyz` 503 (no DB-ready signal) | 2 |

## OpenAPI parity

```text
$ curl -s -H 'Accept: application/json' :8080/v3/api-docs | jq '.paths | keys | length'
21
```

All 21 `/v1/*` paths present (plus `/healthz`, `/readyz`). `/swagger-ui.html` → 302 redirect to `/q/swagger-ui/` (200). OpenAPI contract is fine; the runtime router is what's diverging.

## Recommendation

#16 should stay **open**. Suggest splitting follow-ups along blast radius:

- **Highest priority** — F1 (caller-id bridge): every endpoint is effectively caller-unaware. Fix options: (a) add `valueOf(String)` to `CallerId` and a `ContainerRequestFilter` that enforces presence on `/v1/*`, or (b) replace `@RequestHeader CallerId` with `@HeaderParam` directly across 13 controllers. Both options exceed the in-scope-fix budget of this PR (≤ 2 files / ≤ 50 lines).
- **Same fix family** — F2/F3 (route dispatch on `SessionsController` and `ScreenshotsController`): likely the same root cause in `quarkus-spring-web`'s path-pattern handling for class-level `@RequestMapping` without a path var combined with method-level path-var mappings.
- **Independent** — F4 (validation body), F6 (NotAcceptable→500), F7 (capture error body media type): each is a small, contained fix in `ErrorMapper` + one new `ExceptionMapper` subclass.
- **Cosmetic** — F8.

## Test plan

- [x] `./mvnw -pl api -am clean verify` — green
- [x] `./mvnw -pl api quarkus:dev` boots on :8080 with `Profile dev activated` and `jdbc-h2` in installed features
- [x] `/healthz` → 200
- [x] Full route-mount sweep captured (see Findings)
- [x] OpenAPI parity check (21 `/v1/*` paths)
- [x] `X-Request-Id` propagation: generated UUID on absent header, echoed on inbound `smoke-test-123`
- [ ] **Not addressed in this PR**: actually fixing F1–F8 — needs maintainer call on scope.

https://claude.ai/code/session_018k7ydoN9xnXdQc5AJ1ksxq

---
_Generated by [Claude Code](https://claude.ai/code/session_018k7ydoN9xnXdQc5AJ1ksxq)_