### PR TITLE
Quarkus migration — Step 6 (#19): scheduling verification

### DIFF
--- a/api/src/main/java/io/browserservice/api/persistence/BrowserSessionTracker.java
+++ b/api/src/main/java/io/browserservice/api/persistence/BrowserSessionTracker.java
@@ -80,6 +80,7 @@ public class BrowserSessionTracker {
     if (live.isEmpty()) {
       return;
     }
+    log.debug("flushLastUsed: updating last_used_at for {} live sessions", live.size());
     try {
       List<BrowserSessionEntity> rows = BrowserSessionEntity.list("id in ?1", live.keySet());
       for (BrowserSessionEntity entity : rows) {
@@ -101,6 +102,7 @@ public class BrowserSessionTracker {
   @Transactional
   public void recoverOrphanedActiveSessions(@Observes StartupEvent ev) {
     try {
+      log.info("startup: scanning browser_sessions for orphaned ACTIVE rows");
       Instant now = Instant.now();
       List<BrowserSessionEntity> orphans = BrowserSessionEntity.list("status", Status.ACTIVE);
       if (orphans.isEmpty()) {


### PR DESCRIPTION
Closes #19. Refs #13.

## Summary

Verifies that all `@Scheduled` jobs and the `@Observes StartupEvent` hook work on Quarkus's native scheduler. The bulk of the migration work for Step 6 landed preemptively in `34cdfaf` (Step 1's WIP commit) and Step 2; this PR is the close-out + a small observability touch-up.

### State of acceptance criteria at branch-cut

- `BrowserSessionTracker.flushLastUsed()` already on `@Scheduled(every = "30s")` from `io.quarkus.scheduler.Scheduled`.
- `SessionReaper.reap()` already on `@Scheduled(every = "10s")` (the issue refers to `reapSessions()`; the method has always been named `reap()`, no rename).
- `CaptureScreenshotCache.reap()` is a third `@Scheduled` job not mentioned in the issue text — already Quarkus-native.
- `recoverOrphanedActiveSessions(@Observes StartupEvent)` already uses the Quarkus startup pattern.
- `@EnableScheduling` was removed alongside `BrowserServiceApplication` in Step 2.
- Zero remaining `ApplicationReadyEvent` / `@EventListener` usages in `api/src`.

### `SessionReaper.start()` clarification

The issue asks to convert `@EventListener(ApplicationReadyEvent.class)` on `SessionReaper.start()` to `@Observes StartupEvent`. **No such method has ever existed on `SessionReaper`** (verified against the full git history from `b195faa` onward). The only Spring `@EventListener` ever in the project was on `BrowserSessionTracker.recoverOrphanedActiveSessions`, which was converted in Step 1. Meter / counter / gauge registration in `SessionReaper`'s constructor is the conventional CDI pattern, runs before any scheduler tick, and is correctly left as-is.

### Changes in this PR

Two log additions to `api/src/main/java/io/browserservice/api/persistence/BrowserSessionTracker.java` so acceptance criterion #4 ("Logs confirm scheduled execution after boot") is deterministic:

- **INFO** on every boot at the top of `recoverOrphanedActiveSessions(@Observes StartupEvent)` — previously silent when the DB had no orphan rows. Makes the `@Observes StartupEvent` wiring observable on every boot.
- **DEBUG** in `flushLastUsed()` reporting the number of live sessions — keeps steady-state logs quiet but lets reviewers confirm the 30s cadence by raising the tracker's log level.

The 10s `SessionReaper.reap()` already logs per reaped session at INFO, so it needs no additional instrumentation.

## Test plan

- [x] `./mvnw -pl api -am verify` passes locally; `SpringDiWiringSmokeIT` log captures the new startup line:
  ```
  INFO  [io.bro.api.per.BrowserSessionTracker] startup: scanning browser_sessions for orphaned ACTIVE rows
  ```
- [x] `grep -rn "EnableScheduling\|ApplicationReadyEvent\|@EventListener" api/src` returns 0 matches.
- [x] `grep -rn "import.*Scheduled" api/src/main/java` — all three `@Scheduled` imports resolve to `io.quarkus.scheduler.Scheduled`.
- [ ] Manual dev-mode smoke: `./mvnw -pl api quarkus:dev`, create a session with idle TTL = 5s, observe the 10s reaper INFO line fire on expiry.
- [ ] Manual: raise `quarkus.log.category."io.browserservice.api.persistence.BrowserSessionTracker".level=DEBUG`, create a session, confirm `flushLastUsed: updating last_used_at for N live sessions` appears within 30s.

https://claude.ai/code/session_01DcU1jXJ1nc9WQJBAKGs5Nv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DcU1jXJ1nc9WQJBAKGs5Nv)_