### PR TITLE
R10 Phase 0: pin SessionRegistry to single Cloud Run pod (#119)

### DIFF
--- a/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
@@ -28,6 +28,14 @@ import org.springframework.stereotype.Component;
  * Terraform validations on {@code browser_service_min_instances} and {@code
  * browser_service_max_instances} ({@code terraform/variables.tf}).
  *
+ * <p><b>Deploy-window caveat.</b> The Terraform pin is revision-scoped — those Knative autoscaling
+ * annotations cap each revision, not the service as a whole. During a rolling deploy (and any
+ * future canary traffic split), two revisions briefly run in parallel, each with its own JVM and
+ * its own {@code SessionRegistry}. Sessions created against the outgoing revision will 404 once
+ * traffic shifts to the new revision; the reaper TTL eventually reclaims them. This window is
+ * bounded by deploy duration and is accepted as a known limitation of Phase 0 — closing it requires
+ * the Redis-backed registry (R10 Phase 1).
+ *
  * <p>Lifting this constraint is tracked by issue #119 (R10 Phase 1): externalize the registry to
  * Redis and either route by session-affinity or broker WebDriver access via Selenium Grid. See
  * {@code docs/capacity.md} for the operator-facing summary.

--- a/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
@@ -19,10 +19,13 @@ import org.springframework.stereotype.Component;
  * concurrent-session cap. None of this state is shared between pods.
  *
  * <p><b>Single-pod constraint.</b> Because session state is per-JVM, the service MUST run with
- * exactly one Cloud Run instance. If {@code max_instances > 1}, follow-up requests ({@code
- * /sessions/{id}/navigate}, screenshot, close, …) routed by the load balancer to a different pod
- * will fail with {@code SessionNotFoundException} and silently leak the underlying WebDriver on the
- * original pod. This is enforced at the infrastructure layer by a Terraform validation on {@code
+ * exactly one Cloud Run instance — neither horizontal scale-out ({@code max_instances > 1}) nor
+ * scale-to-zero ({@code min_instances = 0}) is safe. With {@code max_instances > 1}, follow-up
+ * requests ({@code /sessions/{id}/navigate}, screenshot, close, …) routed by the load balancer to a
+ * different pod fail with {@code SessionNotFoundException}. With {@code min_instances = 0}, the JVM
+ * (and this map) is discarded between requests, so a follow-up call cold-starts a fresh instance
+ * with an empty registry — same failure mode. Both bounds are pinned at the infrastructure layer by
+ * Terraform validations on {@code browser_service_min_instances} and {@code
  * browser_service_max_instances} ({@code terraform/variables.tf}).
  *
  * <p>Lifting this constraint is tracked by issue #119 (R10 Phase 1): externalize the registry to

--- a/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
@@ -10,6 +10,25 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import org.springframework.stereotype.Component;
 
+/**
+ * In-memory registry of live browser sessions for the current JVM.
+ *
+ * <p>State lives entirely on the heap: a {@link ConcurrentHashMap} of {@link SessionHandle}s
+ * (each holding a live Selenium {@code WebDriver}, a {@link java.util.concurrent.locks.ReentrantLock},
+ * and other non-serializable references) plus a {@link Semaphore} that enforces the per-pod
+ * concurrent-session cap. None of this state is shared between pods.
+ *
+ * <p><b>Single-pod constraint.</b> Because session state is per-JVM, the service MUST run with
+ * exactly one Cloud Run instance. If {@code max_instances > 1}, follow-up requests
+ * ({@code /sessions/{id}/navigate}, screenshot, close, …) routed by the load balancer to a
+ * different pod will fail with {@code SessionNotFoundException} and silently leak the underlying
+ * WebDriver on the original pod. This is enforced at the infrastructure layer by a Terraform
+ * validation on {@code browser_service_max_instances} ({@code terraform/variables.tf}).
+ *
+ * <p>Lifting this constraint is tracked by issue #119 (R10 Phase 1): externalize the registry
+ * to Redis and either route by session-affinity or broker WebDriver access via Selenium Grid.
+ * See {@code docs/capacity.md} for the operator-facing summary.
+ */
 @Component
 public class SessionRegistry {
 

--- a/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
+++ b/api/src/main/java/io/browserservice/api/session/SessionRegistry.java
@@ -13,21 +13,21 @@ import org.springframework.stereotype.Component;
 /**
  * In-memory registry of live browser sessions for the current JVM.
  *
- * <p>State lives entirely on the heap: a {@link ConcurrentHashMap} of {@link SessionHandle}s
- * (each holding a live Selenium {@code WebDriver}, a {@link java.util.concurrent.locks.ReentrantLock},
+ * <p>State lives entirely on the heap: a {@link ConcurrentHashMap} of {@link SessionHandle}s (each
+ * holding a live Selenium {@code WebDriver}, a {@link java.util.concurrent.locks.ReentrantLock},
  * and other non-serializable references) plus a {@link Semaphore} that enforces the per-pod
  * concurrent-session cap. None of this state is shared between pods.
  *
  * <p><b>Single-pod constraint.</b> Because session state is per-JVM, the service MUST run with
- * exactly one Cloud Run instance. If {@code max_instances > 1}, follow-up requests
- * ({@code /sessions/{id}/navigate}, screenshot, close, …) routed by the load balancer to a
- * different pod will fail with {@code SessionNotFoundException} and silently leak the underlying
- * WebDriver on the original pod. This is enforced at the infrastructure layer by a Terraform
- * validation on {@code browser_service_max_instances} ({@code terraform/variables.tf}).
+ * exactly one Cloud Run instance. If {@code max_instances > 1}, follow-up requests ({@code
+ * /sessions/{id}/navigate}, screenshot, close, …) routed by the load balancer to a different pod
+ * will fail with {@code SessionNotFoundException} and silently leak the underlying WebDriver on the
+ * original pod. This is enforced at the infrastructure layer by a Terraform validation on {@code
+ * browser_service_max_instances} ({@code terraform/variables.tf}).
  *
- * <p>Lifting this constraint is tracked by issue #119 (R10 Phase 1): externalize the registry
- * to Redis and either route by session-affinity or broker WebDriver access via Selenium Grid.
- * See {@code docs/capacity.md} for the operator-facing summary.
+ * <p>Lifting this constraint is tracked by issue #119 (R10 Phase 1): externalize the registry to
+ * Redis and either route by session-affinity or broker WebDriver access via Selenium Grid. See
+ * {@code docs/capacity.md} for the operator-facing summary.
  */
 @Component
 public class SessionRegistry {

--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -11,7 +11,8 @@
 ## Single-pod constraint for `SessionRegistry`
 
 The browser-service API is currently constrained to **exactly one Cloud Run
-instance** (`max_instances = 1`).
+instance** (`min_instances = max_instances = 1`). Both bounds are pinned —
+scale-out and scale-to-zero are both unsafe.
 
 ### Why
 
@@ -28,23 +29,34 @@ shareable between pods.
 
 ### Failure mode if relaxed prematurely
 
-With `max_instances > 1`, the load balancer can route a follow-up request
-(`POST /v1/sessions/{id}/navigate`, screenshot, `DELETE`, …) to a different
-pod from the one that created the session. That pod will not find the id in
-its in-memory map and will return `SessionNotFoundException` (HTTP 404). The
-original pod will keep the `WebDriver` open until the reaper TTL fires,
-leaking a Selenium worker in the interim. Customers see intermittent 404s
-under any kind of multi-pod deployment (canary, rolling, autoscaling burst).
+Two ways this breaks:
+
+1. **`max_instances > 1`** — the load balancer can route a follow-up request
+   (`POST /v1/sessions/{id}/navigate`, screenshot, `DELETE`, …) to a
+   different pod from the one that created the session. That pod will not
+   find the id in its in-memory map and will return
+   `SessionNotFoundException` (HTTP 404). The original pod will keep the
+   `WebDriver` open until the reaper TTL fires, leaking a Selenium worker
+   in the interim. Customers see intermittent 404s under any kind of
+   multi-pod deployment (canary, rolling, autoscaling burst).
+2. **`min_instances = 0`** — Cloud Run is allowed to scale the sole API
+   instance to zero between requests. The JVM is shut down and its heap
+   (including `SessionRegistry`) is discarded. A follow-up
+   `navigate` / `screenshot` / `DELETE` cold-starts a fresh instance with
+   an empty registry → same 404, plus the WebDriver on the discarded
+   instance has been hard-killed rather than gracefully closed.
 
 ### Enforcement
 
 The constraint is enforced at the infrastructure layer:
 
-- `terraform/variables.tf` — `browser_service_max_instances` defaults to `1`
-  and carries a `validation` block that rejects any other value at
-  `terraform plan` time with a pointer to this document and to issue #119.
+- `terraform/variables.tf` — both `browser_service_min_instances` and
+  `browser_service_max_instances` default to `1` and each carries a
+  `validation` block that rejects any other value at `terraform plan`
+  time with a pointer to this document and to issue #119.
 - `terraform/modules/browser_service/main.tf` — inline comment above the
-  `autoscaling.knative.dev/maxScale` annotation explaining the pin.
+  `autoscaling.knative.dev/minScale` / `maxScale` annotations explaining
+  the pin.
 - `SessionRegistry.java` — class-level Javadoc explaining the constraint to
   anyone editing the registry.
 
@@ -61,6 +73,6 @@ Phase 1 (P1, Effort L). Lifting requires either:
    resolve and reattach to the WebDriver via the Grid (true horizontal
    scale, more invasive change).
 
-When Phase 1 lands, the `== 1` validation in `terraform/variables.tf` and the
-inline comments in the module / `SessionRegistry` Javadoc should be removed
-or rewritten.
+When Phase 1 lands, the two `== 1` validations in `terraform/variables.tf`
+and the inline comments in the module / `SessionRegistry` Javadoc should be
+removed or rewritten.

--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -60,6 +60,24 @@ The constraint is enforced at the infrastructure layer:
 - `SessionRegistry.java` — class-level Javadoc explaining the constraint to
   anyone editing the registry.
 
+### Known limitation: deploy windows
+
+The `autoscaling.knative.dev/{min,max}Scale` annotations Terraform sets are
+**revision-scoped**, not service-scoped. During a rolling deploy (or any
+future canary traffic split, see issue #123), Cloud Run briefly runs two
+revisions in parallel — the outgoing one and the incoming one — each with
+its own JVM and its own `SessionRegistry`. Sessions created against the
+outgoing revision will return 404 once traffic shifts to the new revision;
+the reaper TTL eventually reclaims the abandoned `WebDriver`.
+
+This window is bounded by deploy duration (typically seconds to a couple of
+minutes) and is **accepted as a Phase 0 limitation**. The same R10 Phase 1
+work (Redis-backed registry, issue #119) closes it. Until then:
+
+- Deploy during low-traffic windows when possible (see also #145).
+- Do not enable canary traffic splits (#123) until Phase 1 lands, or accept
+  that 10% of in-flight sessions will 404 during the canary window.
+
 ### Lift path
 
 Tracked by **issue #119 (R10 — Externalize `SessionRegistry` to Redis)**,

--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -1,0 +1,66 @@
+# Capacity model
+
+> **Stub.** This document is a placeholder owned by issue **#141 (OPS3 — Capacity
+> model documentation)**, which will expand it into the full sizing model
+> (replicas per concurrent session, vCPU/memory budgets, Postgres connection
+> arithmetic, cost projections at 100 / 500 / 1000 concurrent sessions, and
+> autoscaling thresholds).
+>
+> Until then, only the single section below is authoritative.
+
+## Single-pod constraint for `SessionRegistry`
+
+The browser-service API is currently constrained to **exactly one Cloud Run
+instance** (`max_instances = 1`).
+
+### Why
+
+`SessionRegistry`
+(`api/src/main/java/io/browserservice/api/session/SessionRegistry.java`) keeps
+all live session state on the heap of the API JVM:
+
+- A `ConcurrentHashMap<UUID, SessionHandle>` mapping session id → handle.
+- A `Semaphore` enforcing the per-pod concurrent-session cap.
+
+Each `SessionHandle` holds a live Selenium `WebDriver` reference, a
+`ReentrantLock`, and an `AtomicBoolean`. None of this is serializable or
+shareable between pods.
+
+### Failure mode if relaxed prematurely
+
+With `max_instances > 1`, the load balancer can route a follow-up request
+(`POST /v1/sessions/{id}/navigate`, screenshot, `DELETE`, …) to a different
+pod from the one that created the session. That pod will not find the id in
+its in-memory map and will return `SessionNotFoundException` (HTTP 404). The
+original pod will keep the `WebDriver` open until the reaper TTL fires,
+leaking a Selenium worker in the interim. Customers see intermittent 404s
+under any kind of multi-pod deployment (canary, rolling, autoscaling burst).
+
+### Enforcement
+
+The constraint is enforced at the infrastructure layer:
+
+- `terraform/variables.tf` — `browser_service_max_instances` defaults to `1`
+  and carries a `validation` block that rejects any other value at
+  `terraform plan` time with a pointer to this document and to issue #119.
+- `terraform/modules/browser_service/main.tf` — inline comment above the
+  `autoscaling.knative.dev/maxScale` annotation explaining the pin.
+- `SessionRegistry.java` — class-level Javadoc explaining the constraint to
+  anyone editing the registry.
+
+### Lift path
+
+Tracked by **issue #119 (R10 — Externalize `SessionRegistry` to Redis)**,
+Phase 1 (P1, Effort L). Lifting requires either:
+
+1. **Redis-backed registry** plus LB session affinity by `X-Session-Id`, so
+   any pod can serve any request for an existing session (WebDriver
+   references stay co-located with the owning pod, but the routing table is
+   shared); or
+2. **Redis-backed registry** plus Selenium Grid broker, so any pod can
+   resolve and reattach to the WebDriver via the Grid (true horizontal
+   scale, more invasive change).
+
+When Phase 1 lands, the `== 1` validation in `terraform/variables.tf` and the
+inline comments in the module / `SessionRegistry` Javadoc should be removed
+or rewritten.

--- a/terraform/modules/browser_service/main.tf
+++ b/terraform/modules/browser_service/main.tf
@@ -19,9 +19,10 @@ resource "google_cloud_run_service" "api" {
         # the VPC (otherwise the public *.run.app URL is reached over the
         # internet and rejected by ingress=internal).
         "run.googleapis.com/vpc-access-egress" = "all-traffic"
+        # Both pinned to 1 by root-level validations on browser_service_{min,max}_instances —
+        # SessionRegistry holds session state per-JVM, so neither horizontal scale (> 1) nor
+        # scale-to-zero (< 1) is safe. See issue #119 / docs/capacity.md.
         "autoscaling.knative.dev/minScale" = tostring(var.min_instances)
-        # Pinned to 1 by root-level validation on var.browser_service_max_instances —
-        # SessionRegistry holds session state per-JVM. See issue #119 / docs/capacity.md.
         "autoscaling.knative.dev/maxScale" = tostring(var.max_instances)
       }
     }

--- a/terraform/modules/browser_service/main.tf
+++ b/terraform/modules/browser_service/main.tf
@@ -19,8 +19,10 @@ resource "google_cloud_run_service" "api" {
         # the VPC (otherwise the public *.run.app URL is reached over the
         # internet and rejected by ingress=internal).
         "run.googleapis.com/vpc-access-egress" = "all-traffic"
-        "autoscaling.knative.dev/minScale"        = tostring(var.min_instances)
-        "autoscaling.knative.dev/maxScale"        = tostring(var.max_instances)
+        "autoscaling.knative.dev/minScale" = tostring(var.min_instances)
+        # Pinned to 1 by root-level validation on var.browser_service_max_instances —
+        # SessionRegistry holds session state per-JVM. See issue #119 / docs/capacity.md.
+        "autoscaling.knative.dev/maxScale" = tostring(var.max_instances)
       }
     }
 

--- a/terraform/modules/browser_service/variables.tf
+++ b/terraform/modules/browser_service/variables.tf
@@ -41,7 +41,7 @@ variable "min_instances" {
 }
 
 variable "max_instances" {
-  description = "Maximum Cloud Run instances."
+  description = "Maximum Cloud Run instances. Root-level callers must pin this to 1 until R10 Phase 1 (issue #119) lands — SessionRegistry holds session state per-JVM, so >1 causes silent session loss across pods."
   type        = number
   default     = 10
 }

--- a/terraform/modules/browser_service/variables.tf
+++ b/terraform/modules/browser_service/variables.tf
@@ -35,7 +35,7 @@ variable "vpc_connector_name" {
 }
 
 variable "min_instances" {
-  description = "Minimum warm Cloud Run instances."
+  description = "Minimum warm Cloud Run instances. Root-level callers must pin this to 1 until R10 Phase 1 (issue #119) lands — SessionRegistry holds session state per-JVM, so scale-to-zero evicts live sessions between requests."
   type        = number
   default     = 1
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -118,9 +118,9 @@ variable "browser_service_min_instances" {
 }
 
 variable "browser_service_max_instances" {
-  description = "Maximum browser-service Cloud Run instance count."
+  description = "Maximum browser-service Cloud Run instance count. Pinned to 1: SessionRegistry holds session state in-memory per JVM, so any value > 1 causes silent session loss when the LB routes a follow-up request to a different pod. Lift only after R10 Phase 1 (issue #119) externalizes the registry."
   type        = number
-  default     = 10
+  default     = 1
 
   validation {
     condition     = var.browser_service_max_instances >= 1 && floor(var.browser_service_max_instances) == var.browser_service_max_instances
@@ -130,6 +130,11 @@ variable "browser_service_max_instances" {
   validation {
     condition     = var.browser_service_max_instances >= var.browser_service_min_instances
     error_message = "browser_service_max_instances must be >= browser_service_min_instances."
+  }
+
+  validation {
+    condition     = var.browser_service_max_instances == 1
+    error_message = "browser_service_max_instances must be 1: SessionRegistry holds session state in a per-JVM ConcurrentHashMap and is not shared between pods. Land R10 Phase 1 (Redis-backed registry, issue #119) before relaxing this."
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -107,13 +107,18 @@ variable "browser_service_service_name" {
 }
 
 variable "browser_service_min_instances" {
-  description = "Minimum number of browser-service Cloud Run instances kept warm."
+  description = "Minimum number of browser-service Cloud Run instances kept warm. Pinned to 1 to prevent scale-to-zero: SessionRegistry holds session state on the JVM heap, so a cold-start between requests for the same session causes silent session loss. Lift only after R10 Phase 1 (issue #119) externalizes the registry."
   type        = number
   default     = 1
 
   validation {
     condition     = var.browser_service_min_instances >= 0 && floor(var.browser_service_min_instances) == var.browser_service_min_instances
     error_message = "browser_service_min_instances must be a non-negative integer."
+  }
+
+  validation {
+    condition     = var.browser_service_min_instances == 1
+    error_message = "browser_service_min_instances must be 1: SessionRegistry lives on the JVM heap, so scale-to-zero (or anything > 1) evicts session state between requests. Land R10 Phase 1 (Redis-backed registry, issue #119) before relaxing this."
   }
 }
 


### PR DESCRIPTION
## Summary

Closes the **P0 portion of #119 (R10 Phase 0)** — Phase 1 (Redis-backed registry, P1/L) stays open under the same issue.

`SessionRegistry` (`api/src/main/java/io/browserservice/api/session/SessionRegistry.java`) holds all live session state in a per-JVM `ConcurrentHashMap<UUID, SessionHandle>` + `Semaphore`. `SessionHandle` carries a live Selenium `WebDriver`, a `ReentrantLock`, and an `AtomicBoolean` — none of it serializable. Today the Terraform default is `browser_service_max_instances = 10`, so any real deploy that actually scales past 1 pod will silently drop sessions when the LB routes a follow-up request (`navigate`, screenshot, `DELETE`, …) to a different pod, while the original pod keeps the WebDriver open until the reaper TTL fires.

This PR makes the single-pod constraint impossible to miss and impossible to override without intent:

- **Terraform validation** (`terraform/variables.tf`) — `browser_service_max_instances` default flipped `10 → 1` with a third `validation` block that rejects any other value at `terraform plan` time, pointing at issue #119.
- **Class Javadoc** on `SessionRegistry` describing the in-memory state model, the failure mode under `max_instances > 1`, and the lift path.
- **Inline comment** above the Cloud Run `maxScale` annotation in `terraform/modules/browser_service/main.tf` pointing at the root validation.
- **Tightened description** on the module-level `max_instances` variable so anyone reusing the module sees the constraint.
- **New `docs/capacity.md`** stub — full capacity model is owned by **#141 (OPS3)**; this PR only contributes the "Single-pod constraint" section so the Javadoc and Terraform comments have a stable URL to link to.

```mermaid
flowchart LR
    A[Client] -->|create session| LB[Cloud Run LB]
    LB --> P1[API pod 1]
    P1 -.->|in-memory map| R1[(SessionRegistry<br/>JVM heap)]
    A -->|navigate session id| LB
    LB -.->|"max_instances > 1<br/>(silent session loss)"| P2[API pod 2]
    P2 -.->|"map lookup miss"| R2[(SessionRegistry<br/>different heap)]
    P2 -->|"404 SessionNotFoundException"| A
```

## Test plan

- [x] `./mvnw -pl api -am clean compile -DskipTests` — BUILD SUCCESS (pure Javadoc, no semantic change).
- [ ] `terraform validate` from `terraform/` against `terraform.tfvars.example` (terraform binary not available in this sandbox; HCL pattern mirrors the two existing `validation` blocks in the same variable — happy to fix forward if CI flags anything).
- [ ] `terraform plan` with `browser_service_max_instances = 2` rejects with the new error pointing at R10 Phase 1.
- [ ] `terraform plan` against existing state shows `maxScale: "10" → "1"` on the API service.
- [ ] `docs/capacity.md` renders on GitHub with the stub banner and the Single-pod constraint section.

## Out of scope

- **Phase 1** — Redis-backed registry, `SessionHandle` serialization, lifting the validation. Stays under #119.
- **LB session-affinity by `X-Session-Id`** — explicitly deferred; no LB module exists today.
- **Full capacity model** — owned by #141 (OPS3). This PR only stubs `docs/capacity.md`.

https://claude.ai/code/session_0198aH41oeM7juPs7G5aczrQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0198aH41oeM7juPs7G5aczrQ)_